### PR TITLE
[WIP] feat: reload dialog

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,3 +1,6 @@
+// Product information
+export const PRODUCT_NAME = 'Gemini Power Kit' as const;
+
 // max count of visible items in the capsule bar
 export const MAX_QUICK_FOLLOW_UP_SHOW_ITEMS = 2;
 

--- a/src/common/event.ts
+++ b/src/common/event.ts
@@ -52,6 +52,13 @@ export interface AppEvents {
     from: 'run-modal' | 'manual',
     reason?: string
   };
+  /**
+   * Emitted when the settings panel state changes
+   * @param data.open - Whether the settings panel is open
+   */
+  'settings:state-changed': {
+    open: boolean
+  };
 
   // Chain Prompt
   'execution:aborted-by-chat-switch': {

--- a/src/components/setting-panel/index.tsx
+++ b/src/components/setting-panel/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import { CloseButton, Dialog, Portal, Flex, Box } from "@chakra-ui/react"
-import { useEvent } from "../../hooks/useEventBus"
-import { useColorModeValue } from "../ui/color-mode"
+import { useUpdateEffect } from "ahooks"
+import { useEvent, useEventEmitter } from "../../hooks/useEventBus"
 import { Sidebar } from "./Sidebar"
 import { ContentArea } from "./ContentArea"
 import { registerDefaultViews } from "./views"
@@ -12,6 +12,7 @@ registerDefaultViews()
 
 export const SettingPanel = () => {
   const [open, setOpen] = useState(false)
+  const { emit } = useEventEmitter()
 
   useEvent('settings:open', (data: AppEvents['settings:open']) => {
     setOpen(data.open)
@@ -25,6 +26,11 @@ export const SettingPanel = () => {
   useEvent('settings:close', () => {
     setOpen(false)
   })
+
+  // Emit state change event when open state changes
+  useUpdateEffect(() => {
+    emit('settings:state-changed', { open })
+  }, [open])
 
   return (
     <Dialog.Root 

--- a/src/components/setting-panel/views/about/index.tsx
+++ b/src/components/setting-panel/views/about/index.tsx
@@ -15,8 +15,14 @@ import packageJson from '../../../../../package.json'
 import iconPath from '/icon/512.png'
 
 export const AboutView: SettingViewComponent = () => {
-  // Get extension resource URL when component mounts
   const [logoUrl, setLogoUrl] = useState<string>('')
+  const [version] = useState(() => {
+    try {
+      return (typeof browser !== 'undefined' && browser.runtime?.getManifest()?.version) || packageJson.version
+    } catch {
+      return packageJson.version
+    }
+  })
 
   useEffect(() => {
     setLogoUrl(browser.runtime.getURL(iconPath as any))
@@ -97,9 +103,11 @@ export const AboutView: SettingViewComponent = () => {
                 <Text fontSize="2xl" fontWeight="bold" color={textColor}>
                   {PRODUCT_NAME}
                 </Text>
-                <Badge colorPalette="blue" size="sm">
-                  v{packageJson.version}
-                </Badge>
+                {version && (
+                  <Badge colorPalette="blue" size="sm">
+                    v{version}
+                  </Badge>
+                )}
               </HStack>
               <Text fontSize="md" color={secondaryTextColor}>
                 Your <Text as="span" color={accentColor} fontWeight="medium">Essential Companion</Text> for Gemini
@@ -227,4 +235,3 @@ export const AboutView: SettingViewComponent = () => {
     </Box>
   )
 }
-

--- a/src/components/setting-panel/views/about/index.tsx
+++ b/src/components/setting-panel/views/about/index.tsx
@@ -11,6 +11,7 @@ import { TbMoodShare } from "react-icons/tb";
 import type { SettingViewComponent } from '../../types'
 import { EXTERNAL_LINKS, PRODUCT_NAME } from '@/common/config'
 import { t } from '@/utils/i18n'
+import { isExtensionContextValid } from '@/utils/contextMonitor'
 import packageJson from '../../../../../package.json'
 import iconPath from '/icon/512.png'
 
@@ -25,7 +26,10 @@ export const AboutView: SettingViewComponent = () => {
   })
 
   useEffect(() => {
-    setLogoUrl(browser.runtime.getURL(iconPath as any))
+    // Check if extension context is valid before calling getURL
+    if (isExtensionContextValid()) {
+      setLogoUrl(browser.runtime.getURL(iconPath as any))
+    }
   }, [])
 
   // Color mode values

--- a/src/components/setting-panel/views/about/index.tsx
+++ b/src/components/setting-panel/views/about/index.tsx
@@ -9,7 +9,7 @@ import { FaGithub } from 'react-icons/fa'
 import { LuPuzzle, LuCoffee } from 'react-icons/lu'
 import { TbMoodShare } from "react-icons/tb";
 import type { SettingViewComponent } from '../../types'
-import { EXTERNAL_LINKS } from '@/common/config'
+import { EXTERNAL_LINKS, PRODUCT_NAME } from '@/common/config'
 import { t } from '@/utils/i18n'
 import packageJson from '../../../../../package.json'
 import iconPath from '/icon/512.png'
@@ -95,7 +95,7 @@ export const AboutView: SettingViewComponent = () => {
             <VStack align="flex-start" gap={3} flex={1}>
               <HStack gap={2} align="center">
                 <Text fontSize="2xl" fontWeight="bold" color={textColor}>
-                  {t('aboutPage.productName')}
+                  {PRODUCT_NAME}
                 </Text>
                 <Badge colorPalette="blue" size="sm">
                   v{packageJson.version}
@@ -183,7 +183,7 @@ export const AboutView: SettingViewComponent = () => {
             {t('aboutPage.donate.title')}
           </Text>
           <Text fontSize="sm" color={secondaryTextColor} lineHeight="1.6">
-            {t('aboutPage.donate.description')} 🤗
+            {t('aboutPage.donate.description', PRODUCT_NAME)} 🤗
           </Text>
           <HStack gap={3} w="100%" wrap="wrap">
             <Button

--- a/src/components/setting-panel/views/chain-prompt/ConfirmNewChatDialog.tsx
+++ b/src/components/setting-panel/views/chain-prompt/ConfirmNewChatDialog.tsx
@@ -34,6 +34,8 @@ export const ConfirmNewChatDialog: React.FC<ConfirmNewChatDialogProps> = ({
       open={open} 
       onOpenChange={(e) => !e.open && onClose()}
       size="md"
+      closeOnInteractOutside={false}  // Prevent accidental dismissal during important decision
+      closeOnEscape={true}
     >
       <Portal>
         <Dialog.Backdrop />

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -52,6 +52,8 @@ export function AlertDialog({
       placement="center"
       role="alertdialog"
       size="sm"
+      closeOnInteractOutside={false}  // Alert dialogs require explicit user action
+      closeOnEscape={true}
     >
       <Dialog.Backdrop />
       <Dialog.Positioner>

--- a/src/entrypoints/content/index.tsx
+++ b/src/entrypoints/content/index.tsx
@@ -4,10 +4,18 @@ import './prompt';
 import { renderOverlay } from "./overlay"
 import { chatChangeDetector } from '@/services/chatChangeDetector'
 import { urlMonitor } from '@/services/urlMonitor'
+import { i18nCache } from '@/utils/i18nCache'
 
 export default defineContentScript({
   matches: ['*://gemini.google.com/*'],
+  runAt: 'document_idle',
   async main(ctx) {
+    // Log context creation
+    console.log('[ContentScript] Context created, isValid:', ctx.isValid)
+    
+    // Initialize i18n cache ASAP (before context might be invalidated)
+    i18nCache.initialize()
+    
     // Manually start service modules to ensure correct boot sequence
     console.log('[ContentScript] Starting services...')
     
@@ -45,6 +53,6 @@ export default defineContentScript({
     });
 
     ui.mount();
-    console.log('[ContentScript] UI mounted')
+    console.log('[ContentScript] UI mounted, context still valid:', ctx.isValid)
   },
 });

--- a/src/entrypoints/content/overlay/extension-update/ReloadDialog.tsx
+++ b/src/entrypoints/content/overlay/extension-update/ReloadDialog.tsx
@@ -1,0 +1,65 @@
+import { Button, Dialog, Stack, Text } from '@chakra-ui/react'
+import { i18nCache, CACHE_KEYS } from '@/utils/i18nCache'
+
+interface ReloadDialogProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * Reload Dialog Component
+ * Shows when extension context is invalidated (e.g., after extension reload)
+ * Uses cached i18n strings since extension APIs are no longer available
+ */
+export function ReloadDialog({ isOpen, onClose }: ReloadDialogProps) {
+  const handleReload = () => {
+    // Reload the entire page to get fresh extension context
+    window.location.reload()
+  }
+  
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(e) => !e.open && onClose()}
+      placement="center"
+      size="md"
+      closeOnInteractOutside={false}
+      closeOnEscape={false}
+    >
+      <Dialog.Backdrop />
+      <Dialog.Positioner>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>
+              {i18nCache.get(CACHE_KEYS.EXTENSION_UPDATED_TITLE)}
+            </Dialog.Title>
+            <Dialog.CloseTrigger />
+          </Dialog.Header>
+          
+          <Dialog.Body>
+            <Text>{i18nCache.get(CACHE_KEYS.EXTENSION_UPDATED_BODY)}</Text>
+          </Dialog.Body>
+          
+          <Dialog.Footer>
+            <Stack direction="row" gap={2} width="100%" justify="flex-end">
+              <Button
+                variant="outline"
+                onClick={onClose}
+                size="sm"
+              >
+                {i18nCache.get(CACHE_KEYS.LATER)}
+              </Button>
+              <Button
+                onClick={handleReload}
+                size="sm"
+              >
+                {i18nCache.get(CACHE_KEYS.RELOAD_PAGE)}
+              </Button>
+            </Stack>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog.Positioner>
+    </Dialog.Root>
+  )
+}
+

--- a/src/entrypoints/content/overlay/extension-update/index.tsx
+++ b/src/entrypoints/content/overlay/extension-update/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { monitorExtensionContext } from '@/utils/contextMonitor'
+import { monitorExtensionContext, isExtensionContextValid } from '@/utils/contextMonitor'
+import { useEvent } from '@/hooks/useEventBus'
 import { ReloadDialog } from './ReloadDialog'
 
 /**
@@ -9,6 +10,7 @@ import { ReloadDialog } from './ReloadDialog'
  * 1. Monitor extension context invalidation via polling
  * 2. Display reload dialog when context becomes invalid
  * 3. Stop services gracefully when context becomes invalid
+ * 4. Check context validity when SettingPanel opens
  * 
  * Note: Extension update detection (onUpdateAvailable) has been removed
  * to avoid requiring additional permissions that would trigger user re-authorization.
@@ -26,6 +28,16 @@ function ExtensionUpdate() {
     // Clean up monitoring on unmount
     return stopMonitoring
   }, [])
+
+  // Listen for SettingPanel state changes
+  useEvent('settings:state-changed', (data) => {
+    // When SettingPanel opens, check if context is invalid
+    if (data.open) {
+      if (!isExtensionContextValid()) {
+        setShowReload(true)
+      }
+    }
+  })
 
   return (
     <>

--- a/src/entrypoints/content/overlay/extension-update/index.tsx
+++ b/src/entrypoints/content/overlay/extension-update/index.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from 'react'
-import { chatChangeDetector } from '@/services/chatChangeDetector'
-import { urlMonitor } from '@/services/urlMonitor'
 import { monitorExtensionContext } from '@/utils/contextMonitor'
 import { ReloadDialog } from './ReloadDialog'
 
@@ -21,17 +19,6 @@ function ExtensionUpdate() {
   // Listen for context invalidation via polling
   useEffect(() => {
     const stopMonitoring = monitorExtensionContext(() => {
-      console.info('[ExtensionUpdate] Context invalidated, stopping services...')
-      
-      // Stop all services gracefully
-      try {
-        chatChangeDetector.stop()
-        urlMonitor.stop()
-        console.info('[ExtensionUpdate] Services stopped successfully')
-      } catch (error) {
-        console.error('[ExtensionUpdate] Error stopping services:', error)
-      }
-      
       // Show reload dialog
       setShowReload(true)
     })

--- a/src/entrypoints/content/overlay/index.tsx
+++ b/src/entrypoints/content/overlay/index.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster"
 import { SettingPanel } from "@/components/setting-panel"
 import { useColorMode } from "@/components/ui/color-mode"
 import QuickFollowUp from "./quick-follow-up"
+import ExtensionUpdate from "./extension-update"
 
 function App() {
   const { setTheme } = useColorMode();
@@ -18,6 +19,7 @@ function App() {
       <SettingPanel />
       <Toaster />
       <QuickFollowUp />
+      <ExtensionUpdate />
     </>
   )
 }

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -16,6 +16,7 @@ import {
   useColorMode,
 } from '@/components/ui/color-mode';
 import { t } from '@/utils/i18n';
+import { PRODUCT_NAME } from '@/common/config';
 import { 
   getAllSettings,
   setChatOutlineEnabled,
@@ -113,11 +114,11 @@ function App() {
         <Card.Header pb={2} px={4} pt={4}>
           <Flex justify="space-between" align="center" mb={1}>
             <Heading size="lg" fontWeight="semibold">
-              {t('settingsTitle') || "Gemini Settings"}
+              {t('settingsTitle', PRODUCT_NAME) || "Gemini Settings"}
             </Heading>
           </Flex>
           <Text fontSize="sm" color={secondaryTextColor}>
-            {t('settingsDescription') || "Customize your Gemini chat experience"}
+            {t('settingsDescription', PRODUCT_NAME) || "Customize your Gemini chat experience"}
           </Text>
         </Card.Header>
         

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "Schnellzitat aktivieren",
   "reportIssueLabel": "Problem melden",
   "enableChatOutlineLabel": "Chat-Gliederung aktivieren",
-  "settingsTitle": "Gemini Power Kit Einstellungen",
-  "settingsDescription": "Passen Sie Ihre Gemini Power Kit Erfahrung an",
+  "settingsTitle": "$1 Einstellungen",
+  "settingsDescription": "Passen Sie Ihre $1 Erfahrung an",
   "chatOutlineDescription": "Klickbare Gliederung für einfache Navigation generieren",
   "quickQuoteDescription": "Text auswählen, um schnell zu zitieren und Fragen zu stellen",
   "quickFollow": {
@@ -281,15 +281,13 @@
         "title": "Über",
         "views": {
           "index": {
-            "title": "Über",
-            "description": "Erfahren Sie mehr über Gemini Power Kit"
+            "title": "Über"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Ihr unverzichtbarer Begleiter für Gemini",
     "motivation": {
       "title": "Motivation",
@@ -306,7 +304,7 @@
     },
     "donate": {
       "title": "Projekt unterstützen",
-      "description": "Wenn Gemini Power Kit Ihnen Zeit spart oder Freude bereitet, erwägen Sie bitte, seine Zukunft zu unterstützen",
+      "description": "Wenn $1 Ihnen Zeit spart oder Freude bereitet, erwägen Sie bitte, seine Zukunft zu unterstützen",
       "buyMeCoffee": "Kaffee spenden",
       "share": "Mit Freunden teilen"
     }
@@ -325,6 +323,15 @@
       "description": "Diese Aktion kann nicht rückgängig gemacht werden. Möchten Sie fortfahren?",
       "confirm": "Bestätigen",
       "cancel": "Abbrechen"
-    }
+    },
+    "later": "Später",
+    "cancel": "Abbrechen"
+  },
+  "extension": {
+    "updated": {
+      "title": "Erweiterung aktualisiert",
+      "body": "$1 wurde aktualisiert. Bitte laden Sie diese Seite neu, um die Erweiterung weiter zu verwenden."
+    },
+    "reload_page": "Seite neu laden"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "Enable Quick Follow-up",
   "reportIssueLabel": "Report an Issue",
   "enableChatOutlineLabel": "Enable Chat Outline",
-  "settingsTitle":  "Gemini Power Kit Settings",
-  "settingsDescription": "Customize your Gemini Power Kit experience",
+  "settingsTitle":  "$1 Settings",
+  "settingsDescription": "Customize your $1 experience",
   "chatOutlineDescription": "Generate clickable outline for easy navigation",
   "quickQuoteDescription": "Select text to quickly quote and ask questions",
   "quickFollow": {
@@ -281,15 +281,13 @@
         "title": "About",
         "views": {
           "index": {
-            "title": "About",
-            "description": "Learn more about Gemini Power Kit"
+            "title": "About"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Your Essential Companion for Gemini",
     "motivation": {
       "title": "Motivation",
@@ -306,7 +304,7 @@
     },
     "donate": {
       "title": "Support the Project",
-      "description": "If Gemini Power Kit saves you time or sparks joy, please consider supporting its future",
+      "description": "If $1 saves you time or sparks joy, please consider supporting its future",
       "buyMeCoffee": "Buy me a coffee",
       "share": "Share with friends"
     }
@@ -325,7 +323,16 @@
       "description": "This action cannot be undone. Do you want to continue?",
       "confirm": "Confirm",
       "cancel": "Cancel"
-    }
+    },
+    "later": "Later",
+    "cancel": "Cancel"
+  },
+  "extension": {
+    "updated": {
+      "title": "Extension Updated",
+      "body": "$1 has been updated. Please reload this page to continue using the extension."
+    },
+    "reload_page": "Reload Page"
   }
 }
 

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "Activar Cita Rápida",
   "reportIssueLabel": "Reportar un problema",
   "enableChatOutlineLabel": "Activar Esquema de Chat",
-  "settingsTitle": "Configuración de Gemini Power Kit",
-  "settingsDescription": "Personaliza tu experiencia con Gemini Power Kit",
+  "settingsTitle": "Configuración de $1",
+  "settingsDescription": "Personaliza tu experiencia con $1",
   "chatOutlineDescription": "Generar esquema clicable para navegación fácil",
   "quickQuoteDescription": "Seleccionar texto para citar rápidamente y hacer preguntas",
   "quickFollow": {
@@ -281,15 +281,13 @@
         "title": "Acerca de",
         "views": {
           "index": {
-            "title": "Acerca de",
-            "description": "Conoce más sobre Gemini Power Kit"
+            "title": "Acerca de"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Tu compañero esencial para Gemini",
     "motivation": {
       "title": "Motivación",
@@ -306,7 +304,7 @@
     },
     "donate": {
       "title": "Apoyar el proyecto",
-      "description": "Si Gemini Power Kit te ahorra tiempo o te genera alegría, por favor considera apoyar su futuro",
+      "description": "Si $1 te ahorra tiempo o te genera alegría, por favor considera apoyar su futuro",
       "buyMeCoffee": "Invítame un café",
       "share": "Compartir con amigos"
     }
@@ -325,6 +323,15 @@
       "description": "Esta acción no se puede deshacer. ¿Deseas continuar?",
       "confirm": "Confirmar",
       "cancel": "Cancelar"
-    }
+    },
+    "later": "Más tarde",
+    "cancel": "Cancelar"
+  },
+  "extension": {
+    "updated": {
+      "title": "Extensión actualizada",
+      "body": "$1 se ha actualizado. Por favor, recarga esta página para continuar usando la extensión."
+    },
+    "reload_page": "Recargar página"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "Activer la citation rapide",
   "reportIssueLabel": "Signaler un problème",
   "enableChatOutlineLabel": "Activer le plan de chat",
-  "settingsTitle": "Paramètres Gemini Power Kit",
-  "settingsDescription": "Personnalisez votre expérience Gemini Power Kit",
+  "settingsTitle": "Paramètres $1",
+  "settingsDescription": "Personnalisez votre expérience $1",
   "chatOutlineDescription": "Générer un plan cliquable pour une navigation facile",
   "quickQuoteDescription": "Sélectionner du texte pour citer rapidement et poser des questions",
   "quickFollow": {
@@ -281,15 +281,13 @@
         "title": "À propos",
         "views": {
           "index": {
-            "title": "À propos",
-            "description": "En savoir plus sur Gemini Power Kit"
+            "title": "À propos"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Votre compagnon essentiel pour Gemini",
     "motivation": {
       "title": "Motivation",
@@ -306,7 +304,7 @@
     },
     "donate": {
       "title": "Soutenir le projet",
-      "description": "Si Gemini Power Kit vous fait gagner du temps ou vous apporte de la joie, veuillez envisager de soutenir son avenir",
+      "description": "Si $1 vous fait gagner du temps ou vous apporte de la joie, veuillez envisager de soutenir son avenir",
       "buyMeCoffee": "Offrir un café",
       "share": "Partager avec des amis"
     }
@@ -325,6 +323,15 @@
       "description": "Cette action est irréversible. Voulez-vous continuer ?",
       "confirm": "Confirmer",
       "cancel": "Annuler"
-    }
+    },
+    "later": "Plus tard",
+    "cancel": "Annuler"
+  },
+  "extension": {
+    "updated": {
+      "title": "Extension mise à jour",
+      "body": "$1 a été mis à jour. Veuillez recharger cette page pour continuer à utiliser l'extension."
+    },
+    "reload_page": "Recharger la page"
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "クイック引用を有効にする",
   "reportIssueLabel": "問題を報告",
   "enableChatOutlineLabel": "チャットアウトラインを有効にする",
-  "settingsTitle": "Gemini Power Kit設定",
-  "settingsDescription": "Gemini Power Kit体験をカスタマイズ",
+  "settingsTitle": "$1設定",
+  "settingsDescription": "$1体験をカスタマイズ",
   "chatOutlineDescription": "簡単なナビゲーションのためのクリック可能なアウトラインを生成",
   "quickQuoteDescription": "テキストを選択して素早く引用し質問する",
   "quickFollow": {
@@ -281,15 +281,13 @@
         "title": "について",
         "views": {
           "index": {
-            "title": "について",
-            "description": "Gemini Power Kitについて詳しく知る"
+            "title": "について"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Geminiの必須コンパニオン",
     "motivation": {
       "title": "動機",
@@ -306,7 +304,7 @@
     },
     "donate": {
       "title": "プロジェクトをサポート",
-      "description": "Gemini Power Kitが時間を節約したり、喜びをもたらしたりする場合は、その将来をサポートすることを検討してください",
+      "description": "$1が時間を節約したり、喜びをもたらしたりする場合は、その将来をサポートすることを検討してください",
       "buyMeCoffee": "コーヒーを奢る",
       "share": "友達と共有"
     }
@@ -325,6 +323,15 @@
       "description": "この操作は取り消せません。続行しますか？",
       "confirm": "確認",
       "cancel": "キャンセル"
-    }
+    },
+    "later": "後で",
+    "cancel": "キャンセル"
+  },
+  "extension": {
+    "updated": {
+      "title": "拡張機能が更新されました",
+      "body": "$1 が更新されました。拡張機能を引き続き使用するには、このページを再読み込みしてください。"
+    },
+    "reload_page": "ページを再読み込み"
   }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "빠른 인용 사용",
   "reportIssueLabel": "문제 보고",
   "enableChatOutlineLabel": "채팅 개요 활성화",
-  "settingsTitle": "Gemini Power Kit 설정",
-  "settingsDescription": "Gemini Power Kit 경험을 사용자 정의",
+  "settingsTitle": "$1 설정",
+  "settingsDescription": "$1 경험을 사용자 정의",
   "chatOutlineDescription": "쉬운 탐색을 위한 클릭 가능한 개요 생성",
   "quickQuoteDescription": "텍스트를 선택하여 빠르게 인용하고 질문하기",
   "quickFollow": {
@@ -281,15 +281,13 @@
         "title": "정보",
         "views": {
           "index": {
-            "title": "정보",
-            "description": "Gemini Power Kit에 대해 자세히 알아보기"
+            "title": "정보"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Gemini를 위한 필수 동반자",
     "motivation": {
       "title": "동기",
@@ -306,7 +304,7 @@
     },
     "donate": {
       "title": "프로젝트 지원",
-      "description": "Gemini Power Kit가 시간을 절약하거나 기쁨을 주는 경우, 그 미래를 지원하는 것을 고려해 주세요",
+      "description": "$1가 시간을 절약하거나 기쁨을 주는 경우, 그 미래를 지원하는 것을 고려해 주세요",
       "buyMeCoffee": "커피 사주기",
       "share": "친구와 공유"
     }
@@ -325,6 +323,15 @@
       "description": "이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?",
       "confirm": "확인",
       "cancel": "취소"
-    }
+    },
+    "later": "나중에",
+    "cancel": "취소"
+  },
+  "extension": {
+    "updated": {
+      "title": "확장 프로그램 업데이트됨",
+      "body": "$1가 업데이트되었습니다. 확장 프로그램을 계속 사용하려면 이 페이지를 새로고침하세요."
+    },
+    "reload_page": "페이지 새로고침"
   }
 }

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "Ativar Cotação Rápida",
   "reportIssueLabel": "Reportar um Problema",
   "enableChatOutlineLabel": "Ativar Esboço de Chat",
-  "settingsTitle": "Configurações do Gemini Power Kit",
-  "settingsDescription": "Personalize sua experiência com o Gemini Power Kit",
+  "settingsTitle": "Configurações do $1",
+  "settingsDescription": "Personalize sua experiência com o $1",
   "chatOutlineDescription": "Gerar esboço clicável para navegação fácil",
   "quickQuoteDescription": "Selecionar texto para citar rapidamente e fazer perguntas",
   "quickFollow": {
@@ -281,15 +281,13 @@
         "title": "Sobre",
         "views": {
           "index": {
-            "title": "Sobre",
-            "description": "Saiba mais sobre o Gemini Power Kit"
+            "title": "Sobre"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Seu companheiro essencial para Gemini",
     "motivation": {
       "title": "Motivação",
@@ -306,7 +304,7 @@
     },
     "donate": {
       "title": "Apoiar o projeto",
-      "description": "Se o Gemini Power Kit economiza seu tempo ou traz alegria, considere apoiar seu futuro",
+      "description": "Se o $1 economiza seu tempo ou traz alegria, considere apoiar seu futuro",
       "buyMeCoffee": "Me pague um café",
       "share": "Compartilhar com amigos"
     }
@@ -325,6 +323,15 @@
       "description": "Esta ação não pode ser desfeita. Deseja continuar?",
       "confirm": "Confirmar",
       "cancel": "Cancelar"
-    }
+    },
+    "later": "Mais tarde",
+    "cancel": "Cancelar"
+  },
+  "extension": {
+    "updated": {
+      "title": "Extensão atualizada",
+      "body": "$1 foi atualizado. Por favor, recarregue esta página para continuar usando a extensão."
+    },
+    "reload_page": "Recarregar página"
   }
 }

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "启用快速引用",
   "reportIssueLabel": "报告问题",
   "enableChatOutlineLabel": "启用聊天大纲",
-  "settingsTitle": "Gemini Power Kit 设置",
-  "settingsDescription": "自定义您的 Gemini Power Kit 体验",
+  "settingsTitle": "$1 设置",
+  "settingsDescription": "自定义您的 $1 体验",
   "chatOutlineDescription": "生成可点击大纲，便于导航",
   "quickQuoteDescription": "选择文本快速引用并提问",
   "quickFollow": {
@@ -281,15 +281,13 @@
         "title": "关于",
         "views": {
           "index": {
-            "title": "关于",
-            "description": "了解更多关于 Gemini Power Kit 的信息"
+            "title": "关于"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Gemini 的必备伴侣",
     "motivation": {
       "title": "开发动机",
@@ -306,7 +304,7 @@
     },
     "donate": {
       "title": "支持项目",
-      "description": "如果 Gemini Power Kit 为你节省了时间或带来了快乐，请考虑支持它的未来发展",
+      "description": "如果 $1 为你节省了时间或带来了快乐，请考虑支持它的未来发展",
       "buyMeCoffee": "请我喝咖啡",
       "share": "分享给朋友"
     }
@@ -325,6 +323,15 @@
       "description": "此操作无法撤销，是否继续？",
       "confirm": "确认",
       "cancel": "取消"
-    }
+    },
+    "later": "稍后",
+    "cancel": "取消"
+  },
+  "extension": {
+    "updated": {
+      "title": "插件已更新",
+      "body": "$1 已更新。请刷新此页面以继续使用插件。"
+    },
+    "reload_page": "刷新页面"
   }
 }

--- a/src/locales/zh_TW.json
+++ b/src/locales/zh_TW.json
@@ -8,8 +8,8 @@
   "enableQuickQuoteLabel": "啟用快速引用",
   "reportIssueLabel": "回報問題",
   "enableChatOutlineLabel": "啟用聊天大綱",
-  "settingsTitle": "Gemini Power Kit 設定",
-  "settingsDescription": "自訂您的 Gemini Power Kit 體驗",
+  "settingsTitle": "$1 設定",
+  "settingsDescription": "自訂您的 $1 體驗",
   "chatOutlineDescription": "生成可點擊大綱，便於導航",
   "quickQuoteDescription": "選擇文字快速引用並提問",
   "quickFollow": {
@@ -282,15 +282,13 @@
         "title": "關於",
         "views": {
           "index": {
-            "title": "關於",
-            "description": "了解更多關於 Gemini Power Kit 的資訊"
+            "title": "關於"
           }
         }
       }
     }
   },
   "aboutPage": {
-    "productName": "Gemini Power Kit",
     "tagline": "Gemini 的必備伴侶",
     "motivation": {
       "title": "開發動機",
@@ -307,7 +305,7 @@
     },
     "donate": {
       "title": "支援專案",
-      "description": "如果 Gemini Power Kit 為您節省了時間或帶來了快樂，請考慮支援它的未來發展",
+      "description": "如果 $1 為您節省了時間或帶來了快樂，請考慮支援它的未來發展",
       "buyMeCoffee": "請我喝咖啡",
       "share": "分享給朋友"
     }
@@ -326,6 +324,15 @@
       "description": "此操作無法復原，是否繼續？",
       "confirm": "確認",
       "cancel": "取消"
-    }
+    },
+    "later": "稍後",
+    "cancel": "取消"
+  },
+  "extension": {
+    "updated": {
+      "title": "插件已更新",
+      "body": "$1 已更新。請重新載入此頁面以繼續使用插件。"
+    },
+    "reload_page": "重新載入頁面"
   }
 }

--- a/src/utils/contextMonitor.ts
+++ b/src/utils/contextMonitor.ts
@@ -1,0 +1,216 @@
+/**
+ * Context Monitor Utility
+ * Provides a singleton service to detect extension context invalidation
+ * Supports multiple subscribers with a single monitoring instance
+ */
+
+import { throttle } from './throttle'
+
+type InvalidationCallback = () => void
+
+/**
+ * Singleton Context Monitor
+ * Manages a single polling timer and WXT listener for all subscribers
+ */
+class ContextMonitor {
+  private static instance: ContextMonitor | null = null
+  
+  private callbacks: Set<InvalidationCallback> = new Set()
+  private isInvalidated: boolean = false
+  private pollingIntervalId: number | null = null
+  private handleVisibilityChange: (() => void) | null = null
+  
+  private readonly POLLING_INTERVAL_MS = 60 * 1000
+  private readonly THROTTLE_DELAY_MS = 1000
+  
+  private constructor() {
+    // Create throttled check method
+    this.throttledCheck = throttle(() => {
+      console.info('[ContextMonitor] Checking context validity')
+      if (!ContextMonitor.checkAndNotify()) {
+        console.info('[ContextMonitor] Context invalidated')
+      }
+    }, this.THROTTLE_DELAY_MS)
+  }
+  
+  /**
+   * Throttled check method to prevent excessive checks
+   */
+  private throttledCheck: () => void
+  
+  /**
+   * Get singleton instance
+   */
+  public static getInstance(): ContextMonitor {
+    if (!ContextMonitor.instance) {
+      ContextMonitor.instance = new ContextMonitor()
+    }
+    return ContextMonitor.instance
+  }
+  
+  /**
+   * Check if extension context is still valid (pure function)
+   * Static method - can be called without instance
+   * @returns true if context is valid, false otherwise
+   */
+  public static isContextValid(): boolean {
+    try {
+      return Boolean(browser?.runtime?.id)
+    } catch {
+      return false
+    }
+  }
+  
+  /**
+   * Check context validity and trigger callbacks if invalid
+   * Use this when you want automatic notification on invalidation
+   * @returns true if context is valid, false otherwise
+   */
+  public static checkAndNotify(): boolean {
+    const isValid = ContextMonitor.isContextValid()
+    if (!isValid) {
+      ContextMonitor.getInstance().triggerCallbacks()
+    }
+    return isValid
+  }
+  
+  /**
+   * Trigger all registered callbacks
+   */
+  private triggerCallbacks(): void {
+    if (this.isInvalidated) return
+    
+    this.isInvalidated = true
+    console.warn('[ContextMonitor] Extension context invalidated, notifying subscribers')
+    
+    // Notify all subscribers
+    this.callbacks.forEach(callback => {
+      try {
+        callback()
+      } catch (error) {
+        console.error('[ContextMonitor] Error in callback:', error)
+      }
+    })
+    
+    // Clean up monitoring resources
+    this.stopMonitoring()
+  }
+  
+  /**
+   * Start monitoring (lazy initialization)
+   */
+  private startMonitoring(): void {
+    // Already monitoring
+    if (this.pollingIntervalId !== null) return
+    
+    console.log('[ContextMonitor] Starting monitoring...')
+    
+    // 1. Polling detection (every 60 seconds)
+    this.pollingIntervalId = setInterval(() => {
+      this.throttledCheck()
+    }, this.POLLING_INTERVAL_MS) as any
+    
+    // 2. Visibility change detection (when page becomes visible)
+    this.handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        console.log('[ContextMonitor] Page became visible, checking context...')
+        this.throttledCheck()
+      }
+    }
+    document.addEventListener('visibilitychange', this.handleVisibilityChange)
+  }
+  
+  /**
+   * Stop monitoring
+   */
+  private stopMonitoring(): void {
+    // Stop polling
+    if (this.pollingIntervalId !== null) {
+      clearInterval(this.pollingIntervalId)
+      this.pollingIntervalId = null
+    }
+    
+    // Remove visibility change listener
+    if (this.handleVisibilityChange) {
+      document.removeEventListener('visibilitychange', this.handleVisibilityChange)
+      this.handleVisibilityChange = null
+    }
+    
+    console.log('[ContextMonitor] Monitoring stopped')
+  }
+  
+  /**
+   * Subscribe to context invalidation events
+   * @param callback Function to call when context becomes invalid
+   * @returns Unsubscribe function
+   */
+  public subscribe(callback: InvalidationCallback): () => void {
+    // Add callback to set
+    this.callbacks.add(callback)
+    console.log(`[ContextMonitor] Subscriber added (total: ${this.callbacks.size})`)
+    
+    // Start monitoring if this is the first subscriber
+    if (this.callbacks.size === 1 && !this.isInvalidated) {
+      this.startMonitoring()
+    }
+    
+    // If already invalidated, call immediately
+    if (this.isInvalidated) {
+      try {
+        callback()
+      } catch (error) {
+        console.error('[ContextMonitor] Error in callback:', error)
+      }
+    }
+    
+    // Return unsubscribe function
+    return () => {
+      this.callbacks.delete(callback)
+      console.log(`[ContextMonitor] Subscriber removed (total: ${this.callbacks.size})`)
+      
+      // Stop monitoring if no more subscribers
+      if (this.callbacks.size === 0 && !this.isInvalidated) {
+        this.stopMonitoring()
+      }
+    }
+  }
+  
+  /**
+   * Check if context is currently invalidated
+   */
+  public isInvalid(): boolean {
+    return this.isInvalidated
+  }
+}
+
+/**
+ * Get the singleton ContextMonitor instance
+ */
+export function getContextMonitor(): ContextMonitor {
+  return ContextMonitor.getInstance()
+}
+
+/**
+ * Check if extension context is currently valid
+ * Utility function that can be called from anywhere
+ * @returns true if context is valid, false otherwise
+ */
+export function isExtensionContextValid(): boolean {
+  return ContextMonitor.isContextValid()
+}
+
+/**
+ * Convenience function: Monitor for extension context invalidation
+ * @param callback Function to call when context becomes invalid
+ * @returns Unsubscribe function
+ */
+export function monitorExtensionContext(
+  callback: () => void
+): () => void {
+  const monitor = getContextMonitor()
+  
+  // Subscribe to invalidation events
+  return monitor.subscribe(callback)
+}
+
+

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,21 +1,44 @@
 import { i18n as wxtI18n } from '#i18n'
+import { isExtensionContextValid } from './contextMonitor'
 
 export function t(id: string, substitutions?: string | string[] | number) {
-  // Prefer WXT i18n if available (typesafe, supports plural helpers)
-  if (wxtI18n && typeof wxtI18n.t === 'function') {
-    if (substitutions === undefined) return (wxtI18n.t as any)(id)
-    if (typeof substitutions === 'number') return (wxtI18n.t as any)(id, substitutions)
-    if (Array.isArray(substitutions)) return (wxtI18n.t as any)(id, substitutions)
-    // Single string substitution → wrap as array for `$1`
-    return wxtI18n.t(id, [substitutions])
+  // If context is invalid, return the key itself as fallback
+  // The i18nCache should be used for post-invalidation scenarios
+  if (!isExtensionContextValid()) {
+    console.warn('[i18n] Extension context invalid, returning key:', id)
+    return id
   }
-  // Fallback to browser.i18n: accepts string|string[] for substitutions; pluralization is manual
-  const subs = typeof substitutions === 'number' ? String(substitutions) : substitutions
-  return (globalThis as any).browser?.i18n?.getMessage?.(id, subs) || id
+
+  try {
+    // Prefer WXT i18n if available (typesafe, supports plural helpers)
+    if (wxtI18n && typeof wxtI18n.t === 'function') {
+      if (substitutions === undefined) return (wxtI18n.t as any)(id)
+      if (typeof substitutions === 'number') return (wxtI18n.t as any)(id, substitutions)
+      if (Array.isArray(substitutions)) return (wxtI18n.t as any)(id, substitutions)
+      // Single string substitution → wrap as array for `$1`
+      return wxtI18n.t(id, [substitutions])
+    }
+    // Fallback to browser.i18n: accepts string|string[] for substitutions; pluralization is manual
+    const subs = typeof substitutions === 'number' ? String(substitutions) : substitutions
+    return (globalThis as any).browser?.i18n?.getMessage?.(id, subs) || id
+  } catch (error) {
+    // If any error occurs (e.g., context invalidated during call), return key
+    console.warn('[i18n] Error getting translation:', error)
+    return id
+  }
 }
 
 export function getCurrentLocale() {
-  return (globalThis as any).browser?.i18n?.getUILanguage?.() ?? navigator.language
+  // Check context validity before accessing extension APIs
+  if (!isExtensionContextValid()) {
+    return navigator.language
+  }
+  
+  try {
+    return (globalThis as any).browser?.i18n?.getUILanguage?.() ?? navigator.language
+  } catch {
+    return navigator.language
+  }
 }
 
 

--- a/src/utils/i18nCache.ts
+++ b/src/utils/i18nCache.ts
@@ -1,0 +1,213 @@
+import { t } from './i18n'
+import { PRODUCT_NAME } from '@/common/config'
+
+/**
+ * Pre-defined cache keys for critical core strings needed after extension context invalidation
+ * Only includes global/core keys used by the extension infrastructure
+ * Business modules should define their own keys and use preCache() to cache them
+ * 
+ * @example
+ * // In a business module:
+ * const MY_MODULE_KEYS = { KEY1: 'module.key1', KEY2: 'module.key2' } as const
+ * i18nCache.preCache([{ key: MY_MODULE_KEYS.KEY1 }, { key: MY_MODULE_KEYS.KEY2 }])
+ */
+export const CACHE_KEYS = {
+  // Extension update dialog (used when extension context is invalidated)
+  EXTENSION_UPDATED_TITLE: 'extension.updated.title',
+  EXTENSION_UPDATED_BODY: 'extension.updated.body',
+  RELOAD_PAGE: 'extension.reload_page',
+  LATER: 'common.later'
+} as const
+
+/**
+ * Manager for caching i18n strings before extension context becomes invalid
+ * This is necessary because browser.i18n APIs will throw errors after invalidation
+ * 
+ * Uses a unified cache system for both pre-defined and dynamic keys
+ */
+class I18nCacheManager {
+  private cache: Map<string, string> = new Map()
+  private initialized = false
+  
+  /**
+   * Initialize cache on content script startup
+   * Must be called before extension context might be invalidated
+   * Pre-caches only core/global strings (e.g., extension update dialog)
+   * Business modules should call preCache() separately for their own keys
+   */
+  initialize(): void {
+    // Skip if already initialized
+    if (this.initialized) {
+      console.debug('[I18nCache] Already initialized, skipping')
+      return
+    }
+    
+    console.log('[I18nCache] Initializing core keys...')
+    
+    // Cache core extension strings with proper substitution handling
+    try {
+      // Extension update dialog strings (critical for context invalidation scenarios)
+      this.cache.set(CACHE_KEYS.EXTENSION_UPDATED_TITLE, t(CACHE_KEYS.EXTENSION_UPDATED_TITLE))
+      this.cache.set(CACHE_KEYS.EXTENSION_UPDATED_BODY, t(CACHE_KEYS.EXTENSION_UPDATED_BODY, PRODUCT_NAME))
+      this.cache.set(CACHE_KEYS.RELOAD_PAGE, t(CACHE_KEYS.RELOAD_PAGE))
+      this.cache.set(CACHE_KEYS.LATER, t(CACHE_KEYS.LATER))
+      
+      console.log('[I18nCache] Core initialization complete with', this.cache.size, 'keys')
+    } catch (error) {
+      // If i18n fails, use English fallbacks
+      console.warn('[I18nCache] Failed to fetch i18n, using fallbacks:', error)
+      
+      // Extension update dialog fallbacks
+      this.cache.set(CACHE_KEYS.EXTENSION_UPDATED_TITLE, 'Extension Updated')
+      this.cache.set(
+        CACHE_KEYS.EXTENSION_UPDATED_BODY,
+        `${PRODUCT_NAME} has been updated. Please reload this page to continue using the extension.`
+      )
+      this.cache.set(CACHE_KEYS.RELOAD_PAGE, 'Reload Page')
+      this.cache.set(CACHE_KEYS.LATER, 'Later')
+    }
+    
+    this.initialized = true
+  }
+  
+  /**
+   * Check if cache has been initialized
+   */
+  isReady(): boolean {
+    return this.initialized
+  }
+  
+  /**
+   * Clear the cache (mainly for testing)
+   */
+  clear(): void {
+    this.cache.clear()
+    this.initialized = false
+    console.log('[I18nCache] Cache cleared')
+  }
+  
+  /**
+   * Get cached i18n string, with automatic fetch and cache on first access
+   * If not cached, attempts to fetch from i18n and cache it
+   * Safe to call even after extension context invalidation (returns cached value or key as fallback)
+   * 
+   * @param key - i18n key to fetch
+   * @param substitution - optional substitution for the i18n string (string, number, or string array)
+   * @returns cached or fetched i18n string, or the key itself as fallback
+   * 
+   * @example
+   * // Simple usage
+   * const text = i18nCache.get('common.save')
+   * 
+   * // With substitutions
+   * const greeting = i18nCache.get('user.greeting', userName)
+   * const itemsList = i18nCache.get('items.list', ['item1', 'item2'])
+   * const count = i18nCache.get('count.value', 42)
+   * 
+   * // Using pre-defined keys (with autocomplete)
+   * const title = i18nCache.get(CACHE_KEYS.EXTENSION_UPDATED_TITLE)
+   */
+  get(key: string, substitution?: string | number | string[]): string {
+    const cacheKey = this.makeCacheKey(key, substitution)
+    
+    // Return cached value if available
+    if (this.cache.has(cacheKey)) {
+      return this.cache.get(cacheKey)!
+    }
+    
+    // Try to fetch from i18n and cache it
+    try {
+      const value = t(key, substitution)
+      this.cache.set(cacheKey, value)
+      console.debug('[I18nCache] Cached new key:', cacheKey)
+      return value
+    } catch (error) {
+      // Extension context invalidated or key not found
+      console.warn('[I18nCache] Failed to get i18n string for key:', key, error)
+      // Cache the key itself as fallback to avoid repeated attempts
+      this.cache.set(cacheKey, key)
+      return key
+    }
+  }
+  
+  /**
+   * Pre-cache multiple i18n keys at once
+   * Useful for batch caching before extension context might be invalidated
+   * Includes fallback handling for critical strings
+   * 
+   * @param keys - array of key configurations to cache
+   * @param fallbacks - optional fallback values mapped by i18n key (without substitutions)
+   * 
+   * @example
+   * i18nCache.preCache([
+   *   { key: 'common.save' },
+   *   { key: 'user.greeting', substitution: userName },
+   *   { key: 'items.count', substitution: 42 },
+   *   { key: 'items.list', substitution: ['item1', 'item2'] }
+   * ])
+   * 
+   * // With fallbacks for critical strings
+   * i18nCache.preCache(
+   *   [{ key: 'extension.updated.title' }],
+   *   { 'extension.updated.title': 'Extension Updated' }
+   * )
+   */
+  preCache(
+    keys: Array<{ key: string; substitution?: string | number | string[] }>,
+    fallbacks?: Record<string, string>
+  ): void {
+    let successCount = 0
+    let failCount = 0
+    
+    for (const { key, substitution } of keys) {
+      const cacheKey = this.makeCacheKey(key, substitution)
+      
+      // Skip if already cached
+      if (this.cache.has(cacheKey)) {
+        successCount++
+        continue
+      }
+      
+      try {
+        const value = t(key, substitution)
+        this.cache.set(cacheKey, value)
+        successCount++
+      } catch (error) {
+        // Use fallback if provided (fallbacks are already interpolated final strings)
+        // Otherwise cache the key itself as last resort
+        const fallbackValue = fallbacks?.[key] ?? key
+        this.cache.set(cacheKey, fallbackValue)
+        failCount++
+        console.warn('[I18nCache] Failed to fetch key, using fallback:', key)
+      }
+    }
+    
+    console.log(`[I18nCache] Pre-cached ${keys.length} keys (${successCount} success, ${failCount} fallback)`)
+  }
+  
+  /**
+   * Check if a specific key is cached
+   * 
+   * @param key - i18n key
+   * @param substitution - optional substitution (must match what was used when caching)
+   * @returns true if the key is cached
+   */
+  has(key: string, substitution?: string | number | string[]): boolean {
+    const cacheKey = this.makeCacheKey(key, substitution)
+    return this.cache.has(cacheKey)
+  }
+  
+  /**
+   * Create a unique cache key from i18n key and substitution
+   */
+  private makeCacheKey(key: string, substitution?: string | number | string[]): string {
+    if (substitution === undefined) {
+      return key
+    }
+    return `${key}::${JSON.stringify(substitution)}`
+  }
+}
+
+// Export singleton instance
+export const i18nCache = new I18nCacheManager()
+

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,0 +1,69 @@
+/**
+ * Throttle Utility
+ * Limits the rate at which a function can be called
+ */
+
+/**
+ * Creates a throttled function that only invokes the provided function
+ * at most once per specified time period
+ * 
+ * @param func - The function to throttle
+ * @param delayMs - The number of milliseconds to throttle invocations to
+ * @returns A throttled version of the function
+ * 
+ * @example
+ * const throttled = throttle(() => console.log('called'), 1000)
+ * throttled() // executed immediately
+ * throttled() // ignored (within 1 second)
+ * setTimeout(() => throttled(), 1500) // executed (after 1 second)
+ */
+export function throttle<T extends (...args: any[]) => any>(
+  func: T,
+  delayMs: number
+): (...args: Parameters<T>) => void {
+  let lastCallTime = 0
+
+  return function throttled(...args: Parameters<T>): void {
+    const now = Date.now()
+    const timeSinceLastCall = now - lastCallTime
+
+    if (timeSinceLastCall >= delayMs) {
+      lastCallTime = now
+      func(...args)
+    }
+  }
+}
+
+/**
+ * Creates a throttled function with context preservation
+ * Useful for class methods where 'this' context matters
+ * 
+ * @param func - The function to throttle
+ * @param delayMs - The number of milliseconds to throttle invocations to
+ * @returns A throttled version of the function with preserved context
+ * 
+ * @example
+ * class MyClass {
+ *   value = 42
+ *   throttledMethod = throttleWithContext(() => {
+ *     console.log(this.value) // 'this' is preserved
+ *   }, 1000)
+ * }
+ */
+export function throttleWithContext<T extends (...args: any[]) => any>(
+  func: T,
+  delayMs: number
+): (...args: Parameters<T>) => void {
+  let lastCallTime = 0
+
+  return function throttled(this: any, ...args: Parameters<T>): void {
+    const now = Date.now()
+    const timeSinceLastCall = now - lastCallTime
+
+    if (timeSinceLastCall >= delayMs) {
+      lastCallTime = now
+      func.apply(this, args)
+    }
+  }
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a resilient UX for extension reloads and context invalidation, plus safer i18n handling and minor dialog behavior tweaks.
> 
> - Adds `utils/contextMonitor` to detect invalid extension context (polling + visibility) and notifies subscribers
> - Adds `utils/i18nCache` and updates `utils/i18n` to support cached translations and safe fallbacks when context is invalid
> - New overlay module `overlay/extension-update` with `ReloadDialog` that prompts users to reload the page (uses cached i18n); integrated into overlay app
> - Emits `settings:state-changed` from `SettingPanel` and listens in the extension-update module to trigger reload prompt when opened
> - Content script initializes i18n cache early; legacy content and quick-follow overlay pre-cache and read i18n via `i18nCache`
> - About/Popup views use `PRODUCT_NAME`; About guards `browser.runtime.getURL` by context check and shows runtime version when available
> - Tightens dialog behaviors (`closeOnInteractOutside`/`closeOnEscape`) for confirm and chain-prompt dialogs
> - Locales updated: parameterized titles/descriptions, new keys for extension update dialog and common labels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67b7f7b651a104d0f8e6374ca404e37b9232e17a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->