### PR TITLE
feat: add image preview in chat-outline

### DIFF
--- a/src/entrypoints/content/lagecy/style.css
+++ b/src/entrypoints/content/lagecy/style.css
@@ -184,17 +184,111 @@ body.dark-theme, :root[theme=dark] {
 }
 
 .toc-file-icon {
-  width: 16px;
-  height: 16px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
   margin-right: 8px;
   flex-shrink: 0; /* Prevent icon from shrinking */
 }
 
+.toc-file-icon.single-icon {
+  width: 16px;
+  height: 16px;
+}
+
 .toc-file-icon > * {
-  width: 100%;
-  height: 100%;
+  width: 16px;
+  height: 16px;
   object-fit: contain;
   display: block;
+  flex-shrink: 0;
+}
+
+.toc-file-icon-more {
+  font-size: 11px;
+  color: var(--toc-text-color);
+  opacity: 0.7;
+  margin-left: 2px;
+}
+
+/* Image preview with Tippy.js */
+.tippy-box[data-theme~='image-preview'] {
+  background-color: var(--toc-bg-color);
+  border-radius: 8px;
+  box-shadow: var(--toc-shadow);
+  padding: 0; /* Let container handle padding */
+}
+
+.toc-image-preview-container {
+  padding: 8px;
+  max-height: 500px;
+  overflow-y: auto;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.preview-item-wrapper {
+  position: relative;
+  margin-bottom: 8px;
+}
+
+.preview-item-wrapper:last-child {
+  margin-bottom: 0;
+}
+
+.toc-image-preview-container img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+.preview-video-indicator {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  width: 24px;
+  height: 24px;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  pointer-events: none;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  font-size: 10px;
+  padding-top: 1px;
+  padding-left: 1px;
+  box-sizing: border-box;
+}
+
+.preview-item-wrapper.is-video img {
+  filter: brightness(0.9);
+}
+
+.preview-item-wrapper.is-video:hover img {
+  filter: brightness(1);
+}
+
+/* Scrollbar styling for image preview container */
+.toc-image-preview-container::-webkit-scrollbar {
+  width: 8px;
+}
+
+.toc-image-preview-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.toc-image-preview-container::-webkit-scrollbar-thumb {
+  background-color: var(--toc-hover-bg);
+  border-radius: 3px;
+}
+
+.toc-image-preview-container::-webkit-scrollbar-thumb:hover {
+  background-color: var(--toc-text-color);
+  opacity: 0.3;
 }
 
 .toc-item-text {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -325,7 +325,11 @@
       "cancel": "Abbrechen"
     },
     "later": "Später",
-    "cancel": "Abbrechen"
+    "cancel": "Abbrechen",
+    "image": "Bild",
+    "images": "Bilder",
+    "video": "Video",
+    "videos": "Videos"
   },
   "extension": {
     "updated": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -325,7 +325,11 @@
       "cancel": "Cancel"
     },
     "later": "Later",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "image": "Image",
+    "images": "Images",
+    "video": "Video",
+    "videos": "Videos"
   },
   "extension": {
     "updated": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -325,7 +325,11 @@
       "cancel": "Cancelar"
     },
     "later": "Más tarde",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "image": "Imagen",
+    "images": "Imágenes",
+    "video": "Video",
+    "videos": "Videos"
   },
   "extension": {
     "updated": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -325,7 +325,11 @@
       "cancel": "Annuler"
     },
     "later": "Plus tard",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "image": "Image",
+    "images": "Images",
+    "video": "Vidéo",
+    "videos": "Vidéos"
   },
   "extension": {
     "updated": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -325,7 +325,11 @@
       "cancel": "キャンセル"
     },
     "later": "後で",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "image": "画像",
+    "images": "画像",
+    "video": "動画",
+    "videos": "動画"
   },
   "extension": {
     "updated": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -325,7 +325,11 @@
       "cancel": "취소"
     },
     "later": "나중에",
-    "cancel": "취소"
+    "cancel": "취소",
+    "image": "이미지",
+    "images": "이미지",
+    "video": "동영상",
+    "videos": "동영상"
   },
   "extension": {
     "updated": {

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -325,7 +325,11 @@
       "cancel": "Cancelar"
     },
     "later": "Mais tarde",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "image": "Imagem",
+    "images": "Imagens",
+    "video": "Vídeo",
+    "videos": "Vídeos"
   },
   "extension": {
     "updated": {

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -325,7 +325,11 @@
       "cancel": "取消"
     },
     "later": "稍后",
-    "cancel": "取消"
+    "cancel": "取消",
+    "image": "图片",
+    "images": "图片",
+    "video": "视频",
+    "videos": "视频"
   },
   "extension": {
     "updated": {

--- a/src/locales/zh_TW.json
+++ b/src/locales/zh_TW.json
@@ -326,7 +326,11 @@
       "cancel": "取消"
     },
     "later": "稍後",
-    "cancel": "取消"
+    "cancel": "取消",
+    "image": "圖片",
+    "images": "圖片",
+    "video": "影片",
+    "videos": "影片"
   },
   "extension": {
     "updated": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances Chat Outline with attachment awareness and previews.
> 
> - Image/video thumbnail previews using Tippy.js with a singleton; displays up to 4 icons with `+N`, derives labels from filenames or counts, and builds detailed tooltips
> - Adds i18n keys for `common.image(s)` and `common.video(s)` across all locales; pre-caches keys for legacy script
> - Improves UX: idempotent `showPopover`, coordinated hover/pin behavior so previews don’t auto-hide the outline
> - Robust cleanup: destroy all Tippy instances and singleton, clear stored preview data, and disconnect observers to prevent leaks
> - CSS updates: styles for multi-icons, preview container/theme, video indicator overlay, and scrollbar adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16fdeb78caff1b761a83d67f514f3f6ff94e55d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->