### PR TITLE
fix: theme error when select theme manually

### DIFF
--- a/src/entrypoints/content/overlay/index.tsx
+++ b/src/entrypoints/content/overlay/index.tsx
@@ -1,18 +1,14 @@
 import { Provider } from "@/components/ui/provider-shadow-dom"
-import { StrictMode, useEffect } from "react"
+import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { Toaster } from "@/components/ui/toaster"
 import { SettingPanel } from "@/components/setting-panel"
-import { useColorMode } from "@/components/ui/color-mode"
+import { useSyncColorMode } from "@/hooks/useSyncColorMode"
 import QuickFollowUp from "./quick-follow-up"
 import ExtensionUpdate from "./extension-update"
 
 function App() {
-  const { setTheme } = useColorMode();
-
-  useEffect(() => {
-    setTheme('system');
-  }, [])
+  useSyncColorMode()
 
   return (
     <>

--- a/src/entrypoints/content/status/mount.tsx
+++ b/src/entrypoints/content/status/mount.tsx
@@ -8,6 +8,15 @@ import { Provider } from '@/components/ui/provider-shadow-dom'
 import { RunStatusContainer } from '@/components/run-status'
 import { getDefaultChatWindow } from '@/utils/messageUtils'
 import { useChainPromptStore } from '@/stores/chainPromptStore'
+import { useSyncColorMode } from '@/hooks/useSyncColorMode'
+
+/**
+ * Wrapper component to sync color mode with Gemini page theme
+ */
+function RunStatusApp() {
+  useSyncColorMode()
+  return <RunStatusContainer />
+}
 
 type MountResult = { mountEl: HTMLDivElement; root: Root } | null
 
@@ -120,7 +129,7 @@ export async function mountRunStatusUI(remount = false): Promise<MountResult> {
   statusRoot = createRoot(statusMountEl)
   statusRoot.render(
     <Provider host={{ style: { backgroundColor: 'unset' } }}>
-      <RunStatusContainer />
+      <RunStatusApp />
     </Provider>
   )
 

--- a/src/hooks/useSyncColorMode.ts
+++ b/src/hooks/useSyncColorMode.ts
@@ -1,0 +1,74 @@
+/**
+ * Sync color mode with Gemini page theme
+ * 
+ * This hook monitors the body class changes and syncs the Chakra color mode
+ * with the Gemini page theme (dark-theme / light-theme).
+ */
+
+import { useEffect } from 'react'
+import { useColorMode } from '@/components/ui/color-mode'
+
+/**
+ * Get theme from body class
+ */
+function getThemeFromBody(): 'light' | 'dark' | undefined {
+  const body = document.body
+  if (body.classList.contains('dark-theme')) {
+    return 'dark'
+  }
+  if (body.classList.contains('light-theme')) {
+    return 'light'
+  }
+  return undefined
+}
+
+/**
+ * Hook to sync Chakra color mode with Gemini page theme
+ * 
+ * Usage:
+ * ```tsx
+ * function App() {
+ *   useSyncColorMode()
+ *   return <YourContent />
+ * }
+ * ```
+ */
+export function useSyncColorMode() {
+  const { setColorMode } = useColorMode()
+
+  useEffect(() => {
+    const applyTheme = () => {
+      const theme = getThemeFromBody()
+      if (theme) {
+        setColorMode(theme)
+      } else {
+        // Fallback to system preference
+        setColorMode(
+          window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+        )
+      }
+    }
+
+    // Apply theme on mount
+    applyTheme()
+
+    // Observe body class changes
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          applyTheme()
+          break
+        }
+      }
+    })
+
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class'],
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [setColorMode])
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI behavior change that only affects theme selection, but it adds a `MutationObserver` on `document.body` which could cause minor performance issues if misused.
> 
> **Overview**
> Stops forcing `setTheme('system')` in the overlay and instead syncs the overlay’s color mode to the Gemini page theme.
> 
> Adds a new `useSyncColorMode` hook that derives light/dark mode from `document.body` classes (`dark-theme`/`light-theme`) with a system-preference fallback and keeps it updated via a `MutationObserver`.
> 
> Applies the same theme-sync behavior to the run status UI by rendering `RunStatusContainer` through a new wrapper component (`RunStatusApp`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b21d6592aaacf7c5efe7c62a0272e154979d2e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->