### PR TITLE
Show "What's New" toast for first-time users

### DIFF
--- a/src/entrypoints/content/overlay/whats-new/index.tsx
+++ b/src/entrypoints/content/overlay/whats-new/index.tsx
@@ -24,8 +24,12 @@ function WhatsNew() {
         // Get last seen version from storage
         const lastVersion = await getLastSeenVersion()
 
-        // If no last version (first install), save current version and skip
+        // If no last version (first install)
         if (!lastVersion) {
+          // Check if there are release notes to show
+          if (CURRENT_RELEASE_NOTES.length > 0) {
+            setShowToast(true)
+          }
           await setLastSeenVersion(version)
           return
         }


### PR DESCRIPTION
The "What's New" feature now displays the release notes toast to users who have no previous version record in local storage (e.g., on first install). The logic was updated to:
1. Detect if `lastVersion` is missing.
2. If missing, check if `CURRENT_RELEASE_NOTES` are available.
3. Show the toast if notes exist.
4. Update the stored `lastSeenVersion` to the current version.

This change ensures that new users can immediately see what's new in the extension. Existing update logic for users with a version record remains unchanged.

---
*PR created automatically by Jules for task [610242663399896862](https://jules.google.com/task/610242663399896862) started by @RonkTsang*