### PR TITLE
Update chat title selector in tabTitleSync

### DIFF
--- a/src/services/tabTitleSync.ts
+++ b/src/services/tabTitleSync.ts
@@ -78,7 +78,7 @@ class TabTitleSync {
    */
   private checkAndAttachTitleObserver(): void {
     // Priority 1: Chat conversation title
-    let titleElement = document.querySelector('.conversation-title.gds-title-m') as HTMLElement | null
+    let titleElement = document.querySelector('top-bar-actions .conversation-title-container') as HTMLElement | null
     let titleType = 'chat'
     
     // Priority 2: MyStuff page title (with parent container for precision)


### PR DESCRIPTION
This PR updates the CSS selector used to identify the chat conversation title in the `tabTitleSync` service. The new selector `top-bar-actions .conversation-title-container` is intended to provide better compatibility across different views and updates on the Gemini website.

---
*PR created automatically by Jules for task [15695325625754027432](https://jules.google.com/task/15695325625754027432) started by @RonkTsang*