### PR TITLE
[codex] Update release actions for Node 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- Update actions/checkout from v4 to v6 in the Release workflow.
- Update pnpm/action-setup from v4 to v6 in the Release workflow.

## Why

GitHub Actions warns that JavaScript actions running on Node.js 20 are deprecated. These updated action versions use the Node.js 24 action runtime, removing the warning before GitHub forces the runtime default on June 2, 2026.

## Validation

- Inspected the workflow diff.
- No local build was run because this change only updates GitHub Actions action versions.