### PR TITLE
[codex] Fix tab title on blank chat

### DIFF
--- a/src/services/tabTitleSync.test.ts
+++ b/src/services/tabTitleSync.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { eventBus } from '@/utils/eventbus'
+import { TabTitleSync } from './tabTitleSync'
+
+function setupChatTitle(title: string): HTMLElement {
+  document.body.innerHTML = `
+    <div id="app-root">
+      <top-bar-actions>
+        <div class="conversation-title-container">${title}</div>
+      </top-bar-actions>
+    </div>
+  `
+
+  return document.querySelector('.conversation-title-container') as HTMLElement
+}
+
+async function flushMutationObserver(): Promise<void> {
+  await Promise.resolve()
+}
+
+describe('TabTitleSync', () => {
+  let service: TabTitleSync
+
+  beforeEach(() => {
+    eventBus.removeAllListeners('urlchange')
+    window.history.pushState({}, '', '/app/abc123')
+    document.title = 'Gemini'
+    service = new TabTitleSync()
+  })
+
+  afterEach(() => {
+    service?.stop()
+    eventBus.removeAllListeners('urlchange')
+    document.body.innerHTML = ''
+    document.title = ''
+  })
+
+  it('restores fallback title when navigating back to a blank new chat page', async () => {
+    setupChatTitle('Chat A')
+    service.start()
+
+    expect(document.title).toBe('Chat A')
+
+    eventBus.emitSync('urlchange', {
+      url: 'https://gemini.google.com/app',
+      timestamp: Date.now(),
+    })
+
+    expect(document.title).toBe('Gemini')
+
+    document.getElementById('app-root')?.append(document.createElement('div'))
+    await flushMutationObserver()
+
+    expect(document.title).toBe('Gemini')
+  })
+
+  it('reattaches chat title sync after leaving the blank new chat page', () => {
+    setupChatTitle('Chat A')
+    service.start()
+
+    eventBus.emitSync('urlchange', {
+      url: 'https://gemini.google.com/app',
+      timestamp: Date.now(),
+    })
+    expect(document.title).toBe('Gemini')
+
+    eventBus.emitSync('urlchange', {
+      url: 'https://gemini.google.com/app/def456',
+      timestamp: Date.now(),
+    })
+
+    expect(document.title).toBe('Chat A')
+  })
+})

--- a/src/services/tabTitleSync.ts
+++ b/src/services/tabTitleSync.ts
@@ -3,12 +3,16 @@
  * Automatically syncs Gemini chat title to browser tab title using layered MutationObserver strategy
  */
 
-class TabTitleSync {
+import type { URLChangeEvent } from '@/common/event'
+import { eventBus } from '@/utils/eventbus'
+
+export class TabTitleSync {
   private domTreeObserver: MutationObserver | null = null      // Outer: monitors DOM tree
   private titleContentObserver: MutationObserver | null = null // Inner: monitors title content
   private currentTitleElement: HTMLElement | null = null       // Current title element reference
   private lastTitle: string = ''                               // Cache for debouncing
   private fallbackTitle: string = ''                           // Fallback title when no chat title exists
+  private currentUrl: string = window.location.href
   private isActive = false
 
   /**
@@ -18,8 +22,12 @@ class TabTitleSync {
     if (this.isActive) return
     
     this.isActive = true
+    this.currentUrl = window.location.href
     console.log('[TabTitleSync] Starting tab title sync...')
     
+    // Listen to SPA navigation so blank chat pages can restore the default title
+    eventBus.on('urlchange', this.onURLChange)
+
     // Setup outer observer to monitor DOM tree
     this.setupDomTreeObserver()
     
@@ -44,6 +52,9 @@ class TabTitleSync {
     
     // Cleanup inner observer
     this.detachTitleObserver()
+
+    // Remove event bus listener
+    eventBus.off('urlchange', this.onURLChange)
   }
 
   /**
@@ -74,9 +85,31 @@ class TabTitleSync {
   }
 
   /**
+   * URL change callback: reset stale chat title state on blank new chat pages.
+   */
+  private onURLChange = (eventData: URLChangeEvent): void => {
+    this.currentUrl = eventData.url
+
+    if (this.isBlankNewChatUrl(this.currentUrl)) {
+      this.detachTitleObserver()
+      return
+    }
+
+    this.checkAndAttachTitleObserver()
+  }
+
+  /**
    * Check for title element and attach inner observer if found
    */
   private checkAndAttachTitleObserver(): void {
+    if (this.isBlankNewChatUrl(this.currentUrl)) {
+      if (this.currentTitleElement) {
+        console.log('[TabTitleSync] Title element ignored on blank new chat page')
+        this.detachTitleObserver()
+      }
+      return
+    }
+
     // Priority 1: Chat conversation title
     let titleElement = document.querySelector('top-bar-actions .conversation-title-container') as HTMLElement | null
     let titleType = 'chat'
@@ -106,6 +139,15 @@ class TabTitleSync {
       // Title element disappeared
       console.log('[TabTitleSync] Title element disappeared')
       this.detachTitleObserver()
+    }
+  }
+
+  private isBlankNewChatUrl(url: string): boolean {
+    try {
+      const { pathname } = new URL(url, window.location.href)
+      return pathname === '/app' || pathname === '/app/'
+    } catch {
+      return false
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the auto tab rename behavior when navigating from a named Gemini chat back to the blank /app page.

## Root Cause

TabTitleSync only restored the fallback title when the conversation title element disappeared. Gemini can keep the previous .conversation-title-container in the DOM while the SPA URL has already returned to /app, so the extension kept the old chat title in the browser tab.

## Changes

- Subscribe TabTitleSync to internal urlchange events.
- Treat /app and /app/ as blank new chat pages and detach stale title observers there.
- Skip title selector syncing on blank chat pages so stale DOM mutations cannot rewrite the old chat title.
- Add a Vitest regression test for returning to blank chat and reattaching after leaving it.

## Validation

- Manual verification passed.
- pnpm test:run src/services/tabTitleSync.test.ts
- pnpm run compile