### PR TITLE
[codex] Optimize website SEO signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 # Gemini Power Kit - A Chrome Extension for Gemini
 
+[Gemini Power Kit official website](https://gpk.ronktsang.com/) · [Chrome Web Store](https://chromewebstore.google.com/detail/ihakfpnmefdkllhkecanagmienfnmojn?utm_source=item-share-cb)
+
 Transform your [Gemini](https://gemini.google.com) experience with powerful tools designed to boost your productivity and streamline your workflow. Gemini Power Kit is your essential companion, bringing together three powerful features: **Chat Outline**, **Quick Follow-up**, and **Chain Prompt**.
 
 ## Features

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -7,7 +7,7 @@ const nanoidNonSecureCompat = fileURLToPath(new URL('./src/shims/nanoid-non-secu
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://gpkit.ronktsang.com',
+	site: 'https://gpk.ronktsang.com',
 	vite: {
 		resolve: {
 			alias: {

--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,0 +1,1 @@
+https://gpkit.ronktsang.com/* https://gpk.ronktsang.com/:splat 301

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://gpk.ronktsang.com/sitemap-index.xml

--- a/website/src/content/docs/features/chain-prompt.mdx
+++ b/website/src/content/docs/features/chain-prompt.mdx
@@ -1,6 +1,6 @@
 ---
-title: Chain Prompt
-description: "Chain Prompt for Gemini: design reusable multi-step prompt workflows with variables and execution status."
+title: Chain Prompt Automation for Gemini
+description: "Chain Prompt for Google Gemini lets you design reusable multi-step prompt workflows with variables and execution status."
 ---
 
 import { Image } from 'astro:assets';
@@ -14,7 +14,7 @@ import chainPromptImg from '../../../assets/features/chain-prompt.png';
 
 ## Overview
 
-Chain Prompt is a workflow engine for Gemini prompts. It lets you organize multiple steps into one reusable chain and run them in sequence.
+Chain Prompt is a prompt automation tool inside the Gemini Power Kit Chrome extension for Google Gemini. Use this if you want to automate repeated Gemini prompts, run multi-step workflows, or reuse the same prompt chain with different inputs.
 
 ## Key Capabilities
 

--- a/website/src/content/docs/features/chat-outline.mdx
+++ b/website/src/content/docs/features/chat-outline.mdx
@@ -1,6 +1,6 @@
 ---
-title: Chat Outline
-description: "Chat Outline for Gemini: understand long chats quickly, jump to key sections, and stay oriented."
+title: Gemini Chat Outline Extension
+description: "Chat Outline for Google Gemini helps you navigate long chats, jump to key sections, and stay oriented."
 ---
 
 import { Image } from 'astro:assets';
@@ -14,7 +14,7 @@ import chatOutlineInterfaceImg from '../../../assets/features/chat-outline/inter
 
 ## Overview
 
-Chat Outline is a navigation panel for the current Gemini conversation. It converts long chat history into a structured outline so you can jump directly to the part you need.
+Chat Outline is a conversation navigation tool inside the Gemini Power Kit Chrome extension for Google Gemini. Use this if you want to navigate long Gemini chats, scan previous prompts, and jump directly to the part of a conversation you need.
 
 ## Key Capabilities
 

--- a/website/src/content/docs/features/quick-follow-up.mdx
+++ b/website/src/content/docs/features/quick-follow-up.mdx
@@ -1,6 +1,6 @@
 ---
-title: Quick Follow-up
-description: "Quick Follow-up for Gemini: use Ask Gemini for contextual follow-up and Custom Prompt for one-click automation."
+title: Quick Follow-up for Gemini
+description: "Quick Follow-up for Google Gemini lets you ask contextual follow-up questions from selected text and run saved prompts in one click."
 ---
 
 import { Image } from 'astro:assets';
@@ -12,7 +12,7 @@ import customPromptImg from '../../../assets/features/quick-follow-up/custom-pro
 
 ## Overview
 
-Quick Follow-up is a selection-based interaction layer in Gemini. After you select text in a response, a capsule action bar appears near your cursor.
+Quick Follow-up is a selection-based interaction layer inside the Gemini Power Kit Chrome extension for Google Gemini. Use this if you want to ask follow-up questions from selected Gemini text, avoid copy-paste, or run saved prompt actions in one click.
 
 It has two modes:
 

--- a/website/src/content/docs/features/theme.mdx
+++ b/website/src/content/docs/features/theme.mdx
@@ -1,6 +1,6 @@
 ---
-title: Theme
-description: "Customize Gemini with appearance modes, color presets, wallpaper, and Light-mode readability controls for clearer long-session work."
+title: Gemini Theme Customizer
+description: "Customize Google Gemini themes with appearance modes, color presets, wallpaper, and readability controls for clearer long-session work."
 ---
 
 import { Image } from 'astro:assets';
@@ -14,7 +14,7 @@ import themeSettingImg from '../../../assets/features/theme/setting.png';
 
 ## Overview
 
-Theme helps you turn Gemini into a workspace that is easier to read, easier to scan, and better suited for long sessions.
+Theme is a Gemini theme customizer inside the Gemini Power Kit Chrome extension for Google Gemini. Use this if you want to customize Gemini's theme, add wallpaper, tune Light or Dark mode, and keep long sessions readable without leaving the Gemini interface.
 
 Instead of only changing colors, it gives you three layers of control:
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,7 +1,43 @@
 ---
-title: The Pro Kit to Double Your Google Gemini Productivity
-description: A minimal sidebar toolkit built for deep conversation navigation, prompt automation, and a personalized Gemini experience.
+title: Gemini Power Kit - Gemini Extension for Themes, Chat Outline, and Prompt Automation
+description: "Gemini Power Kit is a Google Gemini extension for Gemini themes, Chat Outline navigation, Quick Follow-up actions, and Chain Prompt automation."
 template: splash
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": ["SoftwareApplication", "WebApplication"],
+        "name": "Gemini Power Kit",
+        "description": "Gemini Power Kit is a Chrome extension for Google Gemini that adds themes, Chat Outline navigation, Quick Follow-up actions, and Chain Prompt automation.",
+        "applicationCategory": "BrowserApplication",
+        "operatingSystem": "Chrome, Chromium-based browsers",
+        "browserRequirements": "Requires Google Chrome or another Chromium-based browser.",
+        "url": "https://gpk.ronktsang.com/",
+        "installUrl": "https://chromewebstore.google.com/detail/ihakfpnmefdkllhkecanagmienfnmojn",
+        "sameAs": [
+          "https://github.com/RonkTsang/gemini-chat-extension",
+          "https://chromewebstore.google.com/detail/ihakfpnmefdkllhkecanagmienfnmojn"
+        ],
+        "featureList": [
+          "Gemini themes and wallpaper customization",
+          "Chat Outline navigation for long Gemini conversations",
+          "Quick Follow-up actions for selected text",
+          "Chain Prompt automation for repeated Gemini workflows"
+        ],
+        "author": {
+          "@type": "Person",
+          "name": "RonkTsang",
+          "url": "https://github.com/RonkTsang"
+        },
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
 hero:
   tagline: Stop repeating, start creating. Chat Outline, Quick Follow-up, and Chain Prompt for maximum productivity.
   image:
@@ -22,6 +58,10 @@ import chatOutlineImg from '../../assets/features/chat-outline/interface.png';
 import quickFollowUpImg from '../../assets/features/quick-follow-up.png';
 import chainPromptImg from '../../assets/features/chain-prompt.png';
 import themeImg from '../../assets/features/theme-wallpaper.jpg';
+
+## What is Gemini Power Kit?
+
+Gemini Power Kit is a Chrome extension for Google Gemini. It helps people customize Gemini with visual themes and wallpaper, navigate long chats with Chat Outline, ask follow-up questions from selected text, and automate repeated prompt workflows. It is built for users who keep Gemini open for deep work, research, writing, coding, and daily productivity. Core settings and workflow data stay local on your device.
 
 <div class="value-band">
   <div class="value-pill">

--- a/website/src/content/docs/support/faq.md
+++ b/website/src/content/docs/support/faq.md
@@ -11,6 +11,18 @@ Yes, the extension is completely free and open source.
 
 No. The extension uses **Shadow DOM Isolation**, meaning its styling will never clash with or break Gemini's native interface. We also automatically adapt to both Light and Dark themes!
 
+### Is Gemini Power Kit good for customizing Gemini themes?
+
+Yes. Gemini Power Kit includes a Gemini theme customizer with appearance modes, color presets, wallpaper, and readability controls for long sessions.
+
+### Is Gemini Power Kit useful for long Gemini chats?
+
+Yes. Chat Outline helps you scan long Gemini conversations, jump to earlier prompts, and stay oriented during research, writing, coding, or deep work.
+
+### Can Gemini Power Kit automate repeated Gemini prompts?
+
+Yes. Chain Prompt lets you build reusable multi-step prompt workflows, while Quick Follow-up lets you run saved prompt actions from selected text.
+
 ### Is my data safe?
 
 All of your custom prompts, variables, and preferences are stored locally on your device. The extension does not collect your chat logs or prompts to remote servers.


### PR DESCRIPTION
## Summary
- fixes the website canonical base URL to gpk.ronktsang.com
- adds Cloudflare Pages robots.txt and gpkit-to-gpk redirect rules
- improves homepage and feature-page SEO/GEO copy, including JSON-LD for Gemini Power Kit
- adds README official website link and FAQ entries for product recommendation queries

## Why
The deployed website was advertising gpkit.ronktsang.com in canonical, hreflang, OG, and sitemap output while the public site is gpk.ronktsang.com. This consolidates the crawl/indexing signals around the intended domain and improves AI/search-readable product positioning.

## Validation
- pnpm install --frozen-lockfile
- cd website && pnpm run build
- checked built canonical/OG/hreflang URLs use gpk.ronktsang.com
- checked sitemap has no gpkit.ronktsang.com leakage
- parsed homepage JSON-LD successfully

## Notes
The repository has no master branch; base is main, the current default branch. Chrome Web Store, X, Ko-fi, and other external profile links still need to be updated manually after deployment.