### PR TITLE
[codex] fix notification host access

### DIFF
--- a/docs/feature/model_response_complete_notification/prd.md
+++ b/docs/feature/model_response_complete_notification/prd.md
@@ -46,17 +46,21 @@ Chrome declares the following optional permissions:
 
 ```json
 {
-  "optional_permissions": ["notifications", "webRequest", "offscreen"]
+  "optional_permissions": ["notifications", "webRequest", "offscreen"],
+  "optional_host_permissions": ["*://gemini.google.com/*"]
 }
 ```
 
-Existing Gemini content-script matches already provide required Gemini host access. Declaring the same origin in `optional_host_permissions` is invalid because Chrome treats it as redundant.
+Chrome requests Gemini host access together with `webRequest` because the
+WebRequest API requires access to the observed host. The same origin also
+appears in content-script matches for DOM injection.
 
 When the user enables the feature from the Popup, Chrome requests
-`notifications` and `webRequest` directly from that user gesture. The in-page
-SettingPanel opens the extension action popup, or a popup window fallback, so
-the permission request originates from an extension page confirmation action.
-If either permission is denied, the feature remains disabled.
+`notifications`, `webRequest`, and Gemini host access directly from that user
+gesture. The in-page SettingPanel opens the extension action popup, or a popup
+window fallback, so the permission request originates from an extension page
+confirmation action. If any required capability is denied, the feature remains
+disabled.
 
 Chrome requests optional `offscreen` permission only when the user enables the
 audio setting. Audio permission denial does not disable visual notifications.
@@ -124,7 +128,7 @@ on macOS and uses the browser's default notification behavior.
 ## 7. Acceptance Criteria
 
 1. Chrome new installs and upgrades do not automatically request notification or WebRequest permissions.
-2. Chrome requests `notifications` and `webRequest` only when the user enables the feature.
+2. Chrome requests `notifications`, `webRequest`, and Gemini host access only when the user enables the feature.
 3. Firefox has required `notifications` permission and enables the feature without making a runtime permission request.
 4. A successful standard `StreamGenerate` request in a background tab creates one notification.
 5. Foreground responses are suppressed by default and can be allowed from the

--- a/docs/feature/model_response_complete_notification/tech_plan.md
+++ b/docs/feature/model_response_complete_notification/tech_plan.md
@@ -142,7 +142,7 @@ node scripts/check-i18n.js
 
 Inspect generated manifests:
 
-- Chrome contains optional `notifications` and optional `webRequest`, with no redundant optional Gemini origin declaration.
+- Chrome contains optional `notifications`, optional `webRequest`, and optional Gemini host access for WebRequest observation.
 - Firefox retains required `notifications` and WebRequest permissions.
 - Chrome contains optional `offscreen`; Firefox does not contain `offscreen` or
   the audio Offscreen page.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -30,7 +30,10 @@ This project builds separate Chrome and Firefox extension variants with WXT. Kee
 
 ## Notifications
 
-- Chrome declares `notifications`, `webRequest`, and `offscreen` as optional permissions. Existing Gemini content-script matches already provide required Gemini host access.
+- Chrome declares `notifications`, `webRequest`, and `offscreen` as optional
+  permissions. It also declares `*://gemini.google.com/*` as optional host
+  access because the `webRequest` API requires host access to observe Gemini
+  requests.
 - Chrome Popup requests optional notification permissions directly. The
   in-page SettingPanel opens the extension action popup, with a popup window
   fallback, because a content-script click forwarded to background does not

--- a/docs/web-store/chrome/permission.md
+++ b/docs/web-store/chrome/permission.md
@@ -30,11 +30,17 @@ content or personal information.
 
 ### Host access: `*://gemini.google.com/*`
 
-Host access is required because Gemini Power Kit runs only on Gemini and needs
-to add its user interface inside the Gemini page. The content script reads and
-updates the Gemini page DOM to provide user-facing features such as the chat
-outline, quick quote controls, prompt tools, theme controls, and notification
-content extraction.
+Gemini Power Kit runs only on Gemini. Its content scripts match
+`gemini.google.com` so the extension can add its user interface inside the
+Gemini page. The content script reads and updates the Gemini page DOM to provide
+user-facing features such as the chat outline, quick quote controls, prompt
+tools, theme controls, and notification content extraction.
+
+The Chrome manifest also declares `*://gemini.google.com/*` as optional host
+access for response-complete notifications. This optional host access is
+requested together with optional `webRequest` only after the user explicitly
+enables response-complete notifications, because Chrome requires host access for
+WebRequest observation.
 
 For response-complete notifications, DOM access is used only after the browser
 network completion signal has fired. The extension asks the Gemini content
@@ -56,8 +62,9 @@ collection unrelated to the notification feature.
 ### Optional `webRequest`
 
 The `webRequest` permission is optional on Chrome and is requested together
-with `notifications` only after the user explicitly enables response-complete
-notifications. It is used to observe successful Gemini request completion for:
+with `notifications` and Gemini host access only after the user explicitly
+enables response-complete notifications. It is used to observe successful Gemini
+request completion for:
 
 - `StreamGenerate` standard response completion.
 - Deep Research `batchexecute` lifecycle requests needed to avoid early or

--- a/src/entrypoints/background/responseCompleteNotification/index.test.ts
+++ b/src/entrypoints/background/responseCompleteNotification/index.test.ts
@@ -361,6 +361,7 @@ describe('responseCompleteNotification background V2', () => {
 
     expect(permissionsContainsMock).toHaveBeenCalledWith({
       permissions: ['notifications', 'webRequest'],
+      origins: ['*://gemini.google.com/*'],
     })
     expect(actionOpenPopupMock).toHaveBeenCalledWith({ windowId: 9 })
     expect(windowsCreateMock).not.toHaveBeenCalled()

--- a/src/services/responseCompleteNotificationSettings.ts
+++ b/src/services/responseCompleteNotificationSettings.ts
@@ -5,6 +5,7 @@ import { storage } from '#imports'
 export const RESPONSE_COMPLETE_NOTIFICATION_PERMISSION = 'notifications' as const
 export const RESPONSE_COMPLETE_NOTIFICATION_WEB_REQUEST_PERMISSION = 'webRequest' as const
 export const RESPONSE_COMPLETE_NOTIFICATION_AUDIO_PERMISSION = 'offscreen' as const
+export const RESPONSE_COMPLETE_NOTIFICATION_GEMINI_ORIGIN = '*://gemini.google.com/*' as const
 
 export type NotificationReadiness =
   | 'off'
@@ -77,6 +78,9 @@ export function getResponseCompleteNotificationPermissionRequest(): Browser.perm
     permissions: [
       RESPONSE_COMPLETE_NOTIFICATION_PERMISSION,
       RESPONSE_COMPLETE_NOTIFICATION_WEB_REQUEST_PERMISSION,
+    ],
+    origins: [
+      RESPONSE_COMPLETE_NOTIFICATION_GEMINI_ORIGIN,
     ],
   }
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -47,6 +47,9 @@ export default defineConfig({
         "webRequest",
         "offscreen"
       ],
+      optional_host_permissions: [
+        "*://gemini.google.com/*"
+      ],
       web_accessible_resources: [
         {
           resources: ["url-monitor-main-world.js", "theme-sync-main-world.js", "icon/512.png"],


### PR DESCRIPTION
## Summary

- Add optional Gemini host access to the Chrome manifest so the response-complete notification WebRequest listeners can observe Gemini requests in production builds.
- Include the Gemini origin in the runtime notification permission request.
- Update notification permission docs and the focused background test expectation.

## Root Cause

The production Chrome manifest declared optional `notifications` and `webRequest`, but did not declare Gemini host access. WXT dev output includes Gemini host permissions, so dev could observe Gemini requests while the packaged production build could not. Test Notification still worked because it only calls `notifications.create()` and does not depend on `webRequest`.

## Validation

- `pnpm test:run src/entrypoints/background/responseCompleteNotification/index.test.ts`
- `pnpm test:run src/entrypoints/background/responseCompleteNotification/audio.test.ts src/entrypoints/background/responseCompleteNotification/deepResearchState.test.ts src/entrypoints/background/responseCompleteNotification/geminiResponseRequest.test.ts src/services/responseCompleteNotificationContent.test.ts`
- `pnpm compile`
- `pnpm build`
- `git diff --check`
- Verified `.output/chrome-mv3/manifest.json` contains `optional_host_permissions: ["*://gemini.google.com/*"]`.