### PR TITLE
[codex] fix Library open-in-new-tab buttons

### DIFF
--- a/src/entrypoints/background/firefox.ts
+++ b/src/entrypoints/background/firefox.ts
@@ -1,5 +1,5 @@
 import { browser } from 'wxt/browser'
-import { isStuffMediaRequest, parseMediaResponse } from '@/utils/stuffMediaParser'
+import { isStuffMediaSourcePath, parseMediaResponse } from '@/utils/stuffMediaParser'
 import {
   FIREFOX_GET_INSTANCE_ID_MESSAGE,
   OPEN_IN_NEW_TAB_MESSAGE,
@@ -15,7 +15,6 @@ const firefoxInstanceId = globalThis.crypto?.randomUUID?.()
 type OnBeforeRequestListener = Parameters<typeof browser.webRequest.onBeforeRequest.addListener>[0]
 type OnBeforeRequestDetails = Parameters<OnBeforeRequestListener>[0]
 type OnBeforeRequestResult = ReturnType<OnBeforeRequestListener>
-type RequestBody = OnBeforeRequestDetails extends { requestBody?: infer T } ? T : never
 type OnHeadersReceivedListener = Parameters<typeof browser.webRequest.onHeadersReceived.addListener>[0]
 type OnHeadersReceivedDetails = Parameters<OnHeadersReceivedListener>[0]
 type OnHeadersReceivedResult = ReturnType<OnHeadersReceivedListener>
@@ -29,42 +28,12 @@ type StreamFilter = {
   disconnect: () => void
 }
 
-function extractFReq(requestBody: RequestBody | undefined): string | null {
-  if (!requestBody) {
-    return null
-  }
-
-  const requestBodyFormData = (requestBody as { formData?: Record<string, string[]> }).formData
-  const formValue = requestBodyFormData?.['f.req']?.[0]
-  if (typeof formValue === 'string') {
-    return formValue
-  }
-
-  const rawParts = (requestBody as { raw?: Array<{ bytes?: ArrayBuffer }> }).raw ?? []
-  const rawBytes = rawParts.find((part: { bytes?: ArrayBuffer }) => part.bytes)?.bytes
-  if (!rawBytes) {
-    return null
-  }
-
-  const rawBody = new TextDecoder().decode(rawBytes)
-  const formData = new URLSearchParams(rawBody)
-  return formData.get('f.req')
-}
-
-function shouldTrackRequest(url: string, fReq: string | null): boolean {
-  if (!fReq) {
-    return false
-  }
-
-  return isStuffMediaRequest(url, { 'f.req': fReq })
-}
-
 function shouldTrackByUrl(url: string): boolean {
   try {
     const urlObj = new URL(url)
     return urlObj.pathname === '/_/BardChatUi/data/batchexecute'
       && urlObj.searchParams.get('rpcids') === 'jGArJ'
-      && urlObj.searchParams.get('source-path') === '/mystuff'
+      && isStuffMediaSourcePath(urlObj.searchParams.get('source-path'))
   } catch {
     return false
   }
@@ -78,7 +47,6 @@ function createRequestMonitor() {
     url: string
     tabId: number
     trackedBy: 'before-request' | 'headers-fallback'
-    matchedByBody: boolean
     type?: OnBeforeRequestDetails['type']
     method?: string
     timeStamp?: number
@@ -91,7 +59,6 @@ function createRequestMonitor() {
       url: details.url,
       tracked: !!tracked,
       trackedBy: tracked?.trackedBy,
-      matchedByBody: tracked?.matchedByBody,
       tabId: tracked?.tabId,
       statusCode: details.statusCode,
       fromCache: details.fromCache,
@@ -123,17 +90,10 @@ function createRequestMonitor() {
       return undefined
     }
 
-    const fReq = extractFReq(details.requestBody)
-    const matchedByBody = fReq ? shouldTrackRequest(details.url, fReq) : false
-    if (fReq && !matchedByBody) {
-      return undefined
-    }
-
     trackedRequestIds.set(details.requestId, {
       url: details.url,
       tabId: details.tabId!,
       trackedBy: 'before-request',
-      matchedByBody,
       type: details.type,
       method: details.method,
       timeStamp: details.timeStamp,
@@ -145,8 +105,6 @@ function createRequestMonitor() {
       type: details.type,
       method: details.method,
       timeStamp: details.timeStamp,
-      hasFReq: !!fReq,
-      matchedByBody,
     })
     return undefined
   }
@@ -164,7 +122,6 @@ function createRequestMonitor() {
         url: details.url,
         tabId: details.tabId,
         trackedBy: 'headers-fallback',
-        matchedByBody: false,
         timeStamp: details.timeStamp,
       }
       trackedRequestIds.set(details.requestId, tracked)
@@ -191,7 +148,6 @@ function createRequestMonitor() {
       requestId: details.requestId,
       url: details.url,
       trackedBy: tracked.trackedBy,
-      matchedByBody: tracked.matchedByBody,
       statusCode: details.statusCode,
     })
 

--- a/src/entrypoints/content/stuff-page/buttonInjector.test.ts
+++ b/src/entrypoints/content/stuff-page/buttonInjector.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MediaItemStatus, type MediaItem } from '@/utils/stuffMediaParser'
+import { stuffDataCache } from './dataCache'
+import { reconcileOpenInNewTabButtons, stopButtonInjector, tryInjectButton } from './buttonInjector'
+
+vi.mock('@/utils/i18n', () => ({
+  t: (id: string) => id,
+}))
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    runtime: {
+      sendMessage: vi.fn(() => Promise.resolve()),
+    },
+  },
+}))
+
+function createMediaItem(overrides: Partial<MediaItem> = {}): MediaItem {
+  return {
+    conversationId: 'c_abc123',
+    responseId: 'r_def456',
+    timestamp: 1781940312,
+    timestampNano: 0,
+    status: MediaItemStatus.Normal,
+    resourceId: 'rc_test',
+    hasImage: true,
+    date: new Date(1781940312 * 1000),
+    ...overrides,
+  }
+}
+
+function renderLibraryCard(): Element {
+  document.body.innerHTML = `
+    <library-sections-overview-page>
+      <div class="media-container">
+        <library-item-card jslog="299880;data:[1,[1781940312,603866744]]">
+          <div class="library-item-card">
+            <div class="header">
+              <div class="title">Image title</div>
+            </div>
+          </div>
+        </library-item-card>
+      </div>
+    </library-sections-overview-page>
+  `
+
+  const card = document.querySelector('library-item-card')
+  if (!card) {
+    throw new Error('Failed to render card')
+  }
+  return card
+}
+
+function getButtons(card: Element): NodeListOf<Element> {
+  return card.querySelectorAll('.gem-ext-open-new-tab-btn')
+}
+
+describe('buttonInjector', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/library')
+    document.body.innerHTML = ''
+    stuffDataCache.clear()
+    stopButtonInjector()
+  })
+
+  afterEach(() => {
+    stopButtonInjector()
+    document.body.innerHTML = ''
+    stuffDataCache.clear()
+  })
+
+  it('does not inject a button when cache data is missing', () => {
+    const card = renderLibraryCard()
+
+    expect(tryInjectButton(card)).toBe(false)
+    expect(getButtons(card)).toHaveLength(0)
+  })
+
+  it('injects a button when cache data is available', () => {
+    const card = renderLibraryCard()
+    stuffDataCache.addItems([createMediaItem()])
+
+    expect(tryInjectButton(card)).toBe(true)
+
+    const button = card.querySelector<HTMLElement>('.gem-ext-open-new-tab-btn')
+    expect(button).not.toBeNull()
+    expect(button?.dataset.openUrl).toBe(`${window.location.origin}/app/abc123#def456`)
+  })
+
+  it('does not inject duplicate buttons during repeated reconciliation', () => {
+    const card = renderLibraryCard()
+    stuffDataCache.addItems([createMediaItem()])
+
+    reconcileOpenInNewTabButtons()
+    reconcileOpenInNewTabButtons()
+
+    expect(getButtons(card)).toHaveLength(1)
+  })
+
+  it('reconciles cards that rendered before cache data arrived', () => {
+    const card = renderLibraryCard()
+
+    expect(tryInjectButton(card)).toBe(false)
+    expect(getButtons(card)).toHaveLength(0)
+
+    stuffDataCache.addItems([createMediaItem()])
+    reconcileOpenInNewTabButtons()
+
+    expect(getButtons(card)).toHaveLength(1)
+  })
+})

--- a/src/entrypoints/content/stuff-page/buttonInjector.ts
+++ b/src/entrypoints/content/stuff-page/buttonInjector.ts
@@ -4,18 +4,15 @@
  * Injects "Open in New Tab" buttons to library-item-card elements.
  * Uses MutationObserver to handle dynamically loaded content.
  * 
- * - Uses WeakMap to track card injection state
+ * - Uses WeakSet to track card injection state
  */
 
-
 import { t } from '@/utils/i18n'
-import { handleOpenInNewTab } from './navigation'
+import { handleOpenInNewTab, resolveOpenInNewTabUrl } from './navigation'
 import './style.css'
 
 // Track injected buttons to avoid duplicates
-const injectedCards = new WeakSet<Element>()
-
-
+let injectedCards = new WeakSet<Element>()
 
 // Keep reference to MutationObserver for cleanup
 let mutationObserver: MutationObserver | null = null
@@ -37,22 +34,17 @@ function getOpenInNewTabSvg(): string {
 `.trim()
 }
 
-
-
-
-
 /**
  * Create and inject button for a library-item-card
  * 
  * @param card The library-item-card element (serves as the container)
+ * @param url The pre-resolved absolute navigation URL.
  */
-function injectButton(card: Element): void {
+function injectButton(card: Element, url: string): void {
   // Skip if already injected
   if (injectedCards.has(card)) {
     return
   }
-
-
 
   // Create button element
   const button = document.createElement('div')
@@ -61,12 +53,13 @@ function injectButton(card: Element): void {
   button.setAttribute('role', 'button')
   button.setAttribute('tabindex', '0')
   button.setAttribute('aria-label', t('stuffPage.openInNewTab'))
+  button.dataset.openUrl = url
 
   // Add click handler
   button.addEventListener('click', (e) => {
     e.preventDefault()
     e.stopPropagation()
-    handleOpenInNewTab(card)
+    handleOpenInNewTab(url)
   })
 
   // Add keyboard support (Enter and Space)
@@ -74,7 +67,7 @@ function injectButton(card: Element): void {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       e.stopPropagation()
-      handleOpenInNewTab(card)
+      handleOpenInNewTab(url)
     }
   })
 
@@ -84,8 +77,6 @@ function injectButton(card: Element): void {
   tooltip.textContent = t('stuffPage.openInNewTab')
   button.appendChild(tooltip)
 
-
-
   // Insert button directly into library-item-card
   card.appendChild(button)
 
@@ -94,29 +85,52 @@ function injectButton(card: Element): void {
 }
 
 /**
+ * Inject a button only when the card has resolvable navigation data.
+ */
+export function tryInjectButton(card: Element): boolean {
+  if (injectedCards.has(card)) {
+    return false
+  }
+
+  if (card.querySelector('.gem-ext-open-new-tab-btn')) {
+    injectedCards.add(card)
+    return false
+  }
+
+  const url = resolveOpenInNewTabUrl(card)
+  if (!url) {
+    return false
+  }
+
+  injectButton(card, url)
+  return true
+}
+
+/**
+ * Reconcile currently rendered cards after media data arrives.
+ */
+export function reconcileOpenInNewTabButtons(): void {
+  const cards = document.querySelectorAll('library-sections-overview-page library-item-card')
+  let injectedCount = 0
+
+  cards.forEach((card) => {
+    if (tryInjectButton(card)) {
+      injectedCount++
+    }
+  })
+
+  if (injectedCount > 0) {
+    console.log('[ButtonInjector] Reconciled open-in-new-tab buttons:', injectedCount)
+  }
+}
+
+/**
  * Start monitoring for library-item-card elements
  */
 export function startButtonInjector(): void {
   console.log('[ButtonInjector] Starting button injector...')
 
-
-
-  // Find media container from library-sections-overview-page
-  const overviewPage = document.querySelector('library-sections-overview-page')
-  if (!overviewPage) {
-    console.log('[ButtonInjector] Overview page not found, will retry on DOM changes')
-    // Will be handled by MutationObserver below
-  } else {
-    const mediaContainer = overviewPage.querySelector('.media-container')
-    if (!mediaContainer) {
-      console.log('[ButtonInjector] Media container not found, will retry on DOM changes')
-    } else {
-      // Inject to existing cards
-      const existingCards = mediaContainer.querySelectorAll('library-item-card')
-      console.log('[ButtonInjector] Found', existingCards.length, 'existing cards')
-      existingCards.forEach(card => injectButton(card))
-    }
-  }
+  reconcileOpenInNewTabButtons()
 
   // Setup MutationObserver to watch for new and removed cards
   mutationObserver = new MutationObserver((mutations) => {
@@ -142,9 +156,8 @@ export function startButtonInjector(): void {
 
         if (addedCards.length > 0) {
           console.log('[ButtonInjector] Found', addedCards.length, 'new cards')
-          addedCards.forEach(card => injectButton(card))
+          addedCards.forEach(card => tryInjectButton(card))
         }
-
 
       }
     }
@@ -168,11 +181,9 @@ export function stopButtonInjector(): void {
     mutationObserver.disconnect()
     mutationObserver = null
   }
+  injectedCards = new WeakSet<Element>()
 
-  // Note: WeakMap (injectedCards) will automatically clean up when cards are garbage collected
-  // DOM elements and event listeners attached to them are automatically cleaned up when the parent verification
-  // cards are removed from the DOM.
-
-
+  // Note: WeakSet (injectedCards) will automatically clean up when cards are garbage collected
+  // DOM elements and event listeners are cleaned up when cards are removed from the DOM.
   console.log('[ButtonInjector] Stopped and cleaned up')
 }

--- a/src/entrypoints/content/stuff-page/index.ts
+++ b/src/entrypoints/content/stuff-page/index.ts
@@ -17,7 +17,7 @@ import {
   isStuffMediaDataReceivedMessage,
 } from '@/types/runtime-messages'
 import { stuffDataCache } from './dataCache'
-import { startButtonInjector, stopButtonInjector } from './buttonInjector'
+import { reconcileOpenInNewTabButtons, startButtonInjector, stopButtonInjector } from './buttonInjector'
 
 /**
  * Stuff Page Module State
@@ -94,6 +94,8 @@ class StuffPageModule {
         addedCount,
         totalCached: stuffDataCache.size,
       })
+
+      reconcileOpenInNewTabButtons()
 
       // Emit to event bus for other modules (if needed)
       eventBus.emit('stuff-media:data-received', {

--- a/src/entrypoints/content/stuff-page/navigation.test.ts
+++ b/src/entrypoints/content/stuff-page/navigation.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MediaItemStatus, type MediaItem } from '@/utils/stuffMediaParser'
+import { stuffDataCache } from './dataCache'
+import { resolveOpenInNewTabUrl } from './navigation'
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    runtime: {
+      sendMessage: vi.fn(() => Promise.resolve()),
+    },
+  },
+}))
+
+function createMediaItem(overrides: Partial<MediaItem> = {}): MediaItem {
+  return {
+    conversationId: 'c_abc123',
+    responseId: 'r_def456',
+    timestamp: 1781940312,
+    timestampNano: 0,
+    status: MediaItemStatus.Normal,
+    resourceId: 'rc_test',
+    hasImage: true,
+    date: new Date(1781940312 * 1000),
+    ...overrides,
+  }
+}
+
+function createCard(jslog: string | null): Element {
+  const card = document.createElement('library-item-card')
+  if (jslog) {
+    card.setAttribute('jslog', jslog)
+  }
+  return card
+}
+
+describe('resolveOpenInNewTabUrl', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/library')
+    stuffDataCache.clear()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    stuffDataCache.clear()
+  })
+
+  it('returns an app URL when timestamp data is cached', () => {
+    stuffDataCache.addItems([createMediaItem()])
+    const card = createCard('299880;data:[1,[1781940312,603866744]]')
+
+    expect(resolveOpenInNewTabUrl(card)).toBe(`${window.location.origin}/app/abc123#def456`)
+  })
+
+  it('returns null when timestamp data is missing from cache', () => {
+    const card = createCard('299880;data:[1,[1781940312,603866744]]')
+
+    expect(resolveOpenInNewTabUrl(card)).toBeNull()
+  })
+
+  it('returns an app URL for audio cards matched by title', () => {
+    stuffDataCache.addItems([
+      createMediaItem({
+        conversationId: 'c_audio',
+        responseId: 'r_title',
+        timestamp: 0,
+        status: MediaItemStatus.Audio,
+        title: 'Audio title',
+        hasImage: false,
+      }),
+    ])
+    const card = createCard('299880;data:[3,[]]')
+    card.innerHTML = `
+      <div class="library-item-card">
+        <div class="header">
+          <div class="title">Audio title</div>
+        </div>
+      </div>
+    `
+
+    expect(resolveOpenInNewTabUrl(card)).toBe(`${window.location.origin}/app/audio#title`)
+  })
+
+  it('returns null for cards without usable identifiers', () => {
+    stuffDataCache.addItems([
+      createMediaItem({
+        conversationId: 'c_',
+        responseId: 'r_',
+      }),
+    ])
+    const card = createCard('299880;data:[1,[1781940312,603866744]]')
+
+    expect(resolveOpenInNewTabUrl(card)).toBeNull()
+  })
+
+  it('returns null for missing jslog, malformed jslog, or missing audio title', () => {
+    expect(resolveOpenInNewTabUrl(createCard(null))).toBeNull()
+    expect(resolveOpenInNewTabUrl(createCard('invalid'))).toBeNull()
+    expect(resolveOpenInNewTabUrl(createCard('299880;data:[3,[]]'))).toBeNull()
+  })
+})

--- a/src/entrypoints/content/stuff-page/navigation.ts
+++ b/src/entrypoints/content/stuff-page/navigation.ts
@@ -4,6 +4,7 @@
  * Handles extracting jslog data and opening items in new tabs.
  */
 
+import { browser } from 'wxt/browser'
 import { MediaItemStatus } from '@/utils/stuffMediaParser'
 import { OPEN_IN_NEW_TAB_MESSAGE } from '@/types/runtime-messages'
 import { stuffDataCache } from './dataCache'
@@ -63,24 +64,20 @@ export function extractMediaInfoFromJslog(jslog: string | null): MediaInfo | nul
 }
 
 /**
- * Handle "Open in New Tab" button click
+ * Resolve the final navigation URL for a library-item-card.
  * 
  * @param cardElement The library-item-card element
  */
-export function handleOpenInNewTab(cardElement: Element): void {
+export function resolveOpenInNewTabUrl(cardElement: Element): string | null {
   try {
-    // Extract jslog attribute
     const jslog = cardElement.getAttribute('jslog')
     if (!jslog) {
-      console.warn('[Navigation] No jslog attribute found on card')
-      return
+      return null
     }
 
-    // Extract media info
     const mediaInfo = extractMediaInfoFromJslog(jslog)
     if (!mediaInfo) {
-      console.warn('[Navigation] Could not extract media info from jslog')
-      return
+      return null
     }
 
     let mediaItem = null
@@ -98,48 +95,50 @@ export function handleOpenInNewTab(cardElement: Element): void {
 
       if (title) {
         mediaItem = stuffDataCache.findByTitle(title)
-        if (!mediaItem) {
-          console.warn('[Navigation] MediaItem not found by title:', title)
-        }
-      } else {
-        console.warn('[Navigation] No title found in card element for Audio item')
       }
     }
 
     if (!mediaItem) {
-      console.warn('[Navigation] MediaItem not found in cache. Info:', mediaInfo)
-      return
+      return null
     }
 
-    // Build URL path (remove prefixes: "c_" from conversationId, "r_" from responseId)
     const conversationId = mediaItem.conversationId.replace(/^c_/, '')
     const responseId = mediaItem.responseId.replace(/^r_/, '')
-    const url = `/app/${conversationId}#${responseId}`
-    const absoluteUrl = new URL(url, window.location.origin).href
+    if (!conversationId || !responseId) {
+      return null
+    }
 
+    return new URL(`/app/${conversationId}#${responseId}`, window.location.origin).href
+  } catch (error) {
+    console.error('[Navigation] Error resolving new-tab URL:', error)
+    return null
+  }
+}
+
+/**
+ * Handle "Open in New Tab" button click
+ *
+ * @param url The pre-resolved absolute URL.
+ */
+export function handleOpenInNewTab(url: string): void {
+  try {
     console.log('[Navigation] Opening in new tab:', {
-      timestamp: mediaInfo.timestamp,
-      status: mediaInfo.status,
-      originalConversationId: mediaItem.conversationId,
-      originalResponseId: mediaItem.responseId,
-      conversationId,
-      responseId,
-      url: absoluteUrl,
+      url,
     })
 
     if (import.meta.env.FIREFOX) {
       void browser.runtime.sendMessage({
         type: OPEN_IN_NEW_TAB_MESSAGE,
-        payload: { url: absoluteUrl },
+        payload: { url },
       }).catch((error) => {
         console.warn('[Navigation] Failed to request new tab:', error)
-        window.open(absoluteUrl, '_blank')
+        window.open(url, '_blank')
       })
       return
     }
 
     // Open in new tab
-    window.open(absoluteUrl, '_blank')
+    window.open(url, '_blank')
   } catch (error) {
     console.error('[Navigation] Error opening in new tab:', error)
   }

--- a/src/entrypoints/content/stuff-page/style.css
+++ b/src/entrypoints/content/stuff-page/style.css
@@ -5,11 +5,11 @@ library-item-card {
 
 .gem-ext-open-new-tab-btn {
   position: absolute;
-  right: 4px;
+  right: 46px;
   top: 4px;
-  width: 35px;
+  width: 36px;
   aspect-ratio: 1;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.34);
   border-radius: 100%;
   display: none;
   justify-content: center;
@@ -21,7 +21,7 @@ library-item-card {
 }
 
 .gem-ext-open-new-tab-btn:hover {
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.52);
 }
 
 library-item-card:hover .gem-ext-open-new-tab-btn {

--- a/src/entrypoints/main-world/stuff-monitor.ts
+++ b/src/entrypoints/main-world/stuff-monitor.ts
@@ -8,8 +8,14 @@
  */
 
 import { xhrInterceptor, type XHRRequestSnapshot } from '@/utils/xhrInterceptor'
-import { parseMediaResponse, isStuffMediaRequest, type MediaItem } from '@/utils/stuffMediaParser'
+import { parseMediaResponse } from '@/utils/stuffMediaParser'
 import { GEM_EXT_EVENTS } from '@/common/event'
+
+const STUFF_MEDIA_BATCH_URL_PATTERN = /\/_\/BardChatUi\/data\/batchexecute\?.*rpcids=jGArJ.*source-path=%2Flibrary/
+
+function isSupportedStuffPagePath(pathname: string): boolean {
+  return pathname === '/library' || pathname.startsWith('/library/')
+}
 
 /**
  * Start monitoring Stuff Media API requests
@@ -25,34 +31,22 @@ export function startStuffMonitor(): void {
     console.log('[StuffMonitor Main World] Starting Stuff page monitoring...')
 
     unregisterInterceptor = xhrInterceptor.intercept({
-      // Match Stuff Media API endpoint with source-path parameter
-      urlPattern: /\/_\/BardChatUi\/data\/batchexecute\?.*rpcids=jGArJ.*source-path=%2Fmystuff/,
+      // Match Stuff Media API endpoint with source-path parameter.
+      urlPattern: STUFF_MEDIA_BATCH_URL_PATTERN,
 
       onResponse: (url: string, responseText: string, status: number, requestSnapshot: XHRRequestSnapshot) => {
         try {
-          // url: "/_/BardChatUi/data/batchexecute?rpcids=jGArJ&source-path=%2Fmystuff&bl=boq_assistant-bard-web-server_20260121.00_p1&f.sid=1945670880997184523&hl=en&_reqid=311373&rt=c"
+          // url: "/_/BardChatUi/data/batchexecute?rpcids=jGArJ&source-path=%2Flibrary&bl=boq_assistant-bard-web-server_20260625.12_p1&f.sid=8667359588762092056&hl=en&_reqid=7860267&rt=c"
           const requestURL = new URL(requestSnapshot.url, window.location.origin)
+          const sourcePath = requestURL.searchParams.get('source-path')
           console.log('[StuffMonitor Main World] Intercepted Stuff Media response:', {
             url,
             requestURL: requestURL.toString(),
+            sourcePath,
             status,
             responseLength: responseText.length,
             requestSnapshot,
           })
-
-          if (typeof requestSnapshot.body !== 'string') {
-            return
-          }
-
-          const formData = new URLSearchParams(requestSnapshot.body)
-
-          const isStuffReq = isStuffMediaRequest(requestURL.toString(), {
-            'f.req': formData.get('f.req') || '',
-          })
-
-          if (!isStuffReq) {
-            return
-          }
 
           // Parse the response using stuffMediaParser
           const mediaData = parseMediaResponse(responseText)
@@ -104,12 +98,16 @@ export function startStuffMonitor(): void {
 
   const checkUrl = () => {
     const pathname = window.location.pathname
-    // Match /mystuff or /mystuff/xx
-    const isStuffPage = pathname === '/mystuff' || pathname.startsWith('/mystuff/')
+    // Match the Gemini library media pages.
+    const isStuffPage = isSupportedStuffPagePath(pathname)
 
     if (isStuffPage) {
+      console.log('[StuffMonitor Main World] Supported library page detected:', pathname)
       startIntercept()
     } else {
+      if (unregisterInterceptor) {
+        console.log('[StuffMonitor Main World] Leaving supported library page:', pathname)
+      }
       stopIntercept()
     }
   }

--- a/src/utils/stuffMediaParser.test.ts
+++ b/src/utils/stuffMediaParser.test.ts
@@ -23,6 +23,7 @@ import {
   filterMediaItemsWithImages,
   filterMediaItemsAudio,
   STUFF_REQUEST_TYPES,
+  isStuffMediaSourcePath,
 } from './stuffMediaParser';
 import fs from 'fs';
 import path from 'path';
@@ -35,6 +36,9 @@ const __dirname = path.dirname(__filename);
 // Read test sample data
 const SAMPLE_RESPONSE_PATH = path.resolve(__dirname, '../../test/samples/media-response.txt');
 const sampleResponse = fs.readFileSync(SAMPLE_RESPONSE_PATH, 'utf-8');
+const LIBRARY_REQUEST_PATH = path.resolve(__dirname, '../../.original/library/request.md');
+const libraryRequestMarkdown = fs.readFileSync(LIBRARY_REQUEST_PATH, 'utf-8');
+const libraryResponse = libraryRequestMarkdown.match(/```([\s\S]*?)```/)?.[1]?.trim() ?? '';
 
 describe('stuffMediaParser', () => {
   // ==================== Request Type Identification ====================
@@ -53,7 +57,20 @@ describe('stuffMediaParser', () => {
   });
 
   describe('isStuffMediaRequest', () => {
-    it('should identify valid Media requests', () => {
+    it('should identify current Library media requests', () => {
+      const url =
+        'https://gemini.google.com/_/BardChatUi/data/batchexecute?rpcids=jGArJ&source-path=%2Flibrary';
+      const fReq = encodeURIComponent(
+        JSON.stringify([
+          [['jGArJ', JSON.stringify([STUFF_REQUEST_TYPES.MEDIA, 30]), null, 'generic']],
+        ]),
+      );
+      const formData = { 'f.req': fReq };
+
+      expect(isStuffMediaRequest(url, formData)).toBe(true);
+    });
+
+    it('should reject legacy My Stuff source paths', () => {
       const url =
         'https://gemini.google.com/_/BardChatUi/data/batchexecute?rpcids=jGArJ&source-path=%2Fmystuff';
       const fReq = encodeURIComponent(
@@ -63,7 +80,20 @@ describe('stuffMediaParser', () => {
       );
       const formData = { 'f.req': fReq };
 
-      expect(isStuffMediaRequest(url, formData)).toBe(true);
+      expect(isStuffMediaRequest(url, formData)).toBe(false);
+    });
+
+    it('should reject unsupported source paths', () => {
+      const url =
+        'https://gemini.google.com/_/BardChatUi/data/batchexecute?rpcids=jGArJ&source-path=%2Fapp%2Fc_123';
+      const fReq = encodeURIComponent(
+        JSON.stringify([
+          [['jGArJ', JSON.stringify([STUFF_REQUEST_TYPES.MEDIA, 30]), null, 'generic']],
+        ]),
+      );
+      const formData = { 'f.req': fReq };
+
+      expect(isStuffMediaRequest(url, formData)).toBe(false);
     });
 
     it('should reject non-batchexecute endpoints', () => {
@@ -78,7 +108,7 @@ describe('stuffMediaParser', () => {
 
     it('should reject Docs type requests', () => {
       const url =
-        'https://gemini.google.com/_/BardChatUi/data/batchexecute?rpcids=jGArJ&source-path=%2Fmystuff';
+        'https://gemini.google.com/_/BardChatUi/data/batchexecute?rpcids=jGArJ&source-path=%2Flibrary';
       const fReq = encodeURIComponent(
         JSON.stringify([
           [['jGArJ', JSON.stringify([STUFF_REQUEST_TYPES.DOCS, 30]), null, 'generic']],
@@ -164,6 +194,19 @@ describe('stuffMediaParser', () => {
       expect(titleItems[0].title).toBe('Why Warren Buffett Bought SIRI XM Despite Huge Losses');
     });
 
+    it('should parse current Library media response data', () => {
+      const result = parseMediaResponse(libraryResponse);
+
+      expect(result).not.toBeNull();
+      expect(result?.totalCount).toBeGreaterThan(0);
+
+      const firstItem = result!.items[0];
+      expect(firstItem.conversationId).toBe('c_9f13b6112bdb41cf');
+      expect(firstItem.responseId).toBe('r_bcb2eed9c92e4379');
+      expect(firstItem.timestamp).toBe(1781941629);
+      expect(firstItem.thumbnailUrl).toContain('https://lh3.googleusercontent.com/');
+    });
+
     it('should handle invalid responses', () => {
       expect(parseMediaResponse('not json')).toBeNull();
       expect(parseMediaResponse('{"error": 500}')).toBeNull();
@@ -183,6 +226,13 @@ describe('stuffMediaParser', () => {
 
   // ==================== Utility Functions ====================
   describe('Utility Functions', () => {
+    it('should identify supported Stuff media source paths', () => {
+      expect(isStuffMediaSourcePath('/library')).toBe(true);
+      expect(isStuffMediaSourcePath('/mystuff')).toBe(false);
+      expect(isStuffMediaSourcePath('/app/c_123')).toBe(false);
+      expect(isStuffMediaSourcePath(null)).toBe(false);
+    });
+
     it('should format item with image', () => {
       const item = {
         conversationId: 'conv123',

--- a/src/utils/stuffMediaParser.ts
+++ b/src/utils/stuffMediaParser.ts
@@ -31,6 +31,10 @@ export const STUFF_REQUEST_TYPES = {
   DOCS: [1, 1, 1, 1, 1, 0, 1] as StuffRequestTypeArray,
 } as const;
 
+export const STUFF_MEDIA_SOURCE_PATHS = ['/library'] as const;
+
+export type StuffMediaSourcePath = typeof STUFF_MEDIA_SOURCE_PATHS[number];
+
 /**
  * Stuff request parameters structure
  */
@@ -135,6 +139,10 @@ export function identifyStuffRequestType(typeArray: number[]): 'media' | 'docs' 
   return null;
 }
 
+export function isStuffMediaSourcePath(sourcePath: string | null): sourcePath is StuffMediaSourcePath {
+  return STUFF_MEDIA_SOURCE_PATHS.includes(sourcePath as StuffMediaSourcePath);
+}
+
 /**
  * Determine if it is a Stuff Media request
  *
@@ -157,7 +165,7 @@ export function isStuffMediaRequest(url: string, formData: Record<string, string
     }
 
     // 3. Check source-path
-    if (urlObj.searchParams.get('source-path') !== '/mystuff') {
+    if (!isStuffMediaSourcePath(urlObj.searchParams.get('source-path'))) {
       return false;
     }
 
@@ -251,8 +259,8 @@ export function buildNextPageRequest(
  */
 export function parseMediaResponse(responseText: string): ParsedMediaResponse | null {
   try {
-    // 1. Remove XSSI protection prefix ")]}'\n\n"
-    const cleanText = responseText.replace(/^\)\]\}'\s*\n\s*\n/, '');
+    // 1. Remove XSSI protection prefix. Gemini has used both one and two line breaks after it.
+    const cleanText = responseText.replace(/^\)\]\}'\s*\n+/, '');
 
     // 2. Split by lines
     const lines = cleanText.split('\n').filter((line) => line.trim());


### PR DESCRIPTION
## Summary

Fixes the Gemini Library open-in-new-tab flow after the page moved from the legacy My Stuff path to the current Library route and request shape.

## What Changed

- Track current Library media requests with `source-path=/library` instead of the legacy `/mystuff` path.
- Parse current Library media responses that use a single newline after the XSSI prefix.
- Only inject the open-in-new-tab button when the card can resolve to cached media data, avoiding broken buttons before the media API data arrives.
- Reconcile already-rendered cards after media data is cached, including audio cards resolved by title.
- Keep the Firefox response monitor aligned with the same supported Library source-path logic.
- Adjust the button placement for the current Library card layout.

## Root Cause

The feature was still keyed to the old My Stuff route and request source path, while Gemini now serves this surface under `/library` with `source-path=/library`. Cards could also render before the intercepted media response populated the cache, so the button could appear without enough data to build the final `/app/{conversationId}#{responseId}` URL.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run src/entrypoints/content/stuff-page/buttonInjector.test.ts src/entrypoints/content/stuff-page/navigation.test.ts src/utils/stuffMediaParser.test.ts`

Note: `pnpm compile` / `pnpm test:run ...` were attempted first, but pnpm stopped on the repo's known `ERR_PNPM_IGNORED_BUILDS` approve-builds gate before running the checks. The equivalent local binaries above passed.