### PR TITLE
feat: add Gem Avatar customization

### DIFF
--- a/docs/gem-avatar/index.md
+++ b/docs/gem-avatar/index.md
@@ -1,0 +1,168 @@
+# Character Avatar In Gem
+
+## 1. 目标
+
+为 Gemini Gem 增加本地头像定制能力：
+
+- 用户头像：读取 Gemini 当前页面中的用户头像，仅用于页面展示，不持久化。
+- Gem 头像：用户为每个 Gem 上传一个专属头像，并按 `gemId` 本地持久化。
+- 展示位置：Gem 编辑页的 `bot-logo` 预览、Gem 列表页的 `bot-list-row` logo、Gem 聊天页的 Gem header、用户消息头像、模型消息头像。
+
+## 2. 路由识别
+
+Gem 页面通过 path 判断：
+
+- 新建编辑页：`/gems/create`
+- Gem 列表页：`/gems/view`
+- 已有 Gem 编辑页：`/gems/edit/{gemId}`
+- Gem 新对话：`/gem/{gemId}`
+- Gem 对话：`/gem/{gemId}/{chatId}`
+
+`gemId` 只从路由解析。`/gems/create` 初始没有 `gemId`，需要在用户保存后监听路由变更到 `/gems/edit/{gemId}`，再把 pending 头像写入存储。
+
+## 3. 数据与存储
+
+Gem 头像素材使用 IndexedDB/Dexie 持久化，不放入 `storage.sync` 或 base64 配置中。
+
+建议表结构：
+
+```ts
+interface GemAvatarAssetRow {
+  gemId: string
+  mimeType: 'image/png' | 'image/jpeg' | 'image/webp'
+  size: number
+  blob: Blob
+  width?: number
+  height?: number
+  createdAt: string
+  updatedAt: string
+}
+```
+
+约束：
+
+- 每个 `gemId` 最多一个头像，主键可直接使用 `gemId`。
+- 上传原始文件大小不超过 `3MB`。
+- 文件大小上限必须配置化，例如 `GEM_AVATAR_FILE_SIZE_LIMIT = 3 * 1024 * 1024`，不要把 `3MB` 散落在 UI、校验和测试中。
+- 仅接受 `image/png`、`image/jpeg`、`image/webp`。
+
+## 4. 上传归一化
+
+上传时建议先用 canvas 归一化，再把处理后的 Blob 写入 IndexedDB：
+
+- 中心裁剪为正方形。
+- 输出尺寸使用 `256x256`。
+- 输出格式建议 `image/webp`，质量可配置，例如 `0.9`。
+- 使用 `canvas.toBlob()`，不要使用 `toDataURL()`。
+- 使用 `URL.createObjectURL(file)` 读取原图，加载完成后立即 `URL.revokeObjectURL()`。
+- 只持久化归一化后的头像 Blob，不保存原图。
+
+性能判断：
+
+- 主要成本来自原图解码，而不是 `256x256` 或 `512x512` 的 canvas 绘制。
+- canvas 归一化只发生在用户上传头像时，是一次性成本。
+- 聊天页只读取已归一化的小 Blob 并创建 object URL，不再做裁剪、缩放或重新编码。
+- 归一化可以降低长期 IndexedDB 存储、读取、object URL 创建和 DOM 渲染成本，适合该功能。
+
+## 5. 编辑页注入
+
+目标入口：
+
+```css
+bots-creation-window div.title-container > bot-logo
+```
+
+注入层级：
+
+```html
+<bot-logo>
+  ...
+  <gem-avatar-preview>
+    <gem-avatar></gem-avatar>
+    <gem-avatar-uploader></gem-avatar-uploader>
+  </gem-avatar-preview>
+</bot-logo>
+```
+
+行为：
+
+- `gem-avatar-preview` 层级最高，覆盖原 `bot-logo`。
+- 点击 uploader 打开本地文件选择。
+- 上传成功后立即在 `bot-logo` 内预览。
+- `/gems/edit/{gemId}`：上传后直接写入 `gemId` 对应头像。
+- `/gems/create`：上传后先保存在 content module 的 pending 状态；保存成功并解析到 `gemId` 后写入 IndexedDB。
+- pending 状态必须在写入成功、离开 Gem 编辑页、content script invalidated 时清理。
+- 新建/编辑页内如果存在聊天预览 `infinite-scroller`，同样注入用户/模型头像，但使用小尺寸样式：`32x32`，左右额外偏移量为 `0px`。
+- 新建/编辑页内如果预览聊天区 `infinite-scroller` 下存在任意 `bot-logo`，同样覆盖 Gem 头像。
+
+## 6. Gem 列表页注入
+
+当 path 为 `/gems/view` 时，监听 `div.bots-section-container` 下的 `bot-list-row`。
+
+Gem ID 来源：
+
+```css
+bot-list-row a.bot-row[href^="/gem/"]
+```
+
+从 `href="/gem/{gemId}"` 解析 `gemId`。如果本地存储中存在该 `gemId` 的头像，则覆盖同一行内的：
+
+```css
+bot-list-row bot-logo
+```
+
+列表页会为当前页面中命中的 Gem 头像创建页面级 object URL 缓存；离开列表页或模块停止时必须统一 revoke。
+
+## 7. 聊天页注入
+
+当 path 为 `/gem/{gemId}` 或 `/gem/{gemId}/{chatId}`，并且存储中存在该 `gemId` 的头像时，启用头像展示。
+
+Gem 头像：
+
+- 从 IndexedDB 按 `gemId` 读取 Blob。
+- 转换为 object URL 后注入到 `bot-logo` 和模型消息头像位置。
+- 页面切换 Gem 或模块停止时 revoke object URL。
+
+用户头像：
+
+```css
+sidenav-mavatar-footer > div.mavatar-footer-row > a > div.mavatar-container > img.mavatar-image
+```
+
+读取当前页面 `img.mavatar-image` 的 `currentSrc || src`，只用于当前页面渲染，不持久化。
+
+消息注入位置参考 `.original/characters/demo.html`：
+
+- 用户消息：`user-query-content > div.user-query-container`
+- 模型消息：`response-container > div.response-container`
+
+样式应使用 class + CSS 文件，避免大量 inline style。
+
+## 8. 生命周期与性能边界
+
+- 使用 `urlMonitor` 的 `urlchange` 事件重新解析页面状态。
+- 使用 `MutationObserver` 处理 Gemini DOM 重建和新增消息。
+- 聊天消息区优先监听 `#chat-history infinite-scroller`，列表页优先监听 `div.bots-section-container`，新建/编辑页预览聊天区监听 `bots-creation-window infinite-scroller`。
+- 使用已注入标记避免重复插入头像节点。
+- 任意页面中，只要 Gem 头像注入到 `recent-chat-list-item bot-logo` 下，头像圆角都使用 `calc(var(--bot-logo-size, 32px) / 3)`，不限定于编辑页。
+- 不在 background 中保存头像路由状态。
+- 不保留无界 `Map`/`Set`。如需缓存 object URL，必须按当前 `gemId` 绑定，并在切换或 stop 时清理。
+- DOM 选择器集中管理，便于 Gemini 页面改版时修复。
+
+## 9. MVP 范围
+
+第一阶段实现：
+
+- Gem 编辑页上传、校验、归一化、预览。
+- `/gems/create` 保存后绑定新生成的 `gemId`。
+- `/gems/edit/{gemId}` 直接替换该 Gem 头像。
+- `/gems/view` 列表页展示已配置的 Gem 头像。
+- Gem 聊天页展示 Gem header 头像、用户消息头像、模型消息头像。
+- IndexedDB 持久化和 object URL 清理。
+
+暂不纳入第一阶段：
+
+- 删除头像入口。
+- 裁剪 UI。
+- 多设备同步。
+- 批量导入导出。

--- a/src/components/setting-panel/views/enhancements/index.tsx
+++ b/src/components/setting-panel/views/enhancements/index.tsx
@@ -51,7 +51,7 @@ function FeatureToggleCard({
 export function EnhancementsSettingsView() {
   const [chatOutlineEnabled, setChatOutlineEnabled] = useState(true)
   const [bulkDeleteEnabled, setBulkDeleteEnabled] = useState(true)
-  const [gemAvatarEnabled, setGemAvatarEnabled] = useState(true)
+  const [gemAvatarEnabled, setGemAvatarEnabled] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {

--- a/src/components/setting-panel/views/enhancements/index.tsx
+++ b/src/components/setting-panel/views/enhancements/index.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react'
 import { Box, Container, Stack, Switch, Text } from '@chakra-ui/react'
-import { enableBulkDelete, enableChatOutline } from '@/entrypoints/popup/storage'
+import {
+  enableBulkDelete,
+  enableChatOutline,
+  enableGemAvatar,
+} from '@/entrypoints/popup/storage'
 import { toaster } from '@/components/ui/toaster'
 import { t } from '@/utils/i18n'
 
@@ -47,6 +51,7 @@ function FeatureToggleCard({
 export function EnhancementsSettingsView() {
   const [chatOutlineEnabled, setChatOutlineEnabled] = useState(true)
   const [bulkDeleteEnabled, setBulkDeleteEnabled] = useState(true)
+  const [gemAvatarEnabled, setGemAvatarEnabled] = useState(true)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -54,9 +59,10 @@ export function EnhancementsSettingsView() {
 
     const loadSettings = async () => {
       try {
-        const [chatOutline, bulkDelete] = await Promise.all([
+        const [chatOutline, bulkDelete, gemAvatar] = await Promise.all([
           enableChatOutline.getValue(),
           enableBulkDelete.getValue(),
+          enableGemAvatar.getValue(),
         ])
         if (!isMounted) {
           return
@@ -64,6 +70,7 @@ export function EnhancementsSettingsView() {
 
         setChatOutlineEnabled(chatOutline)
         setBulkDeleteEnabled(bulkDelete)
+        setGemAvatarEnabled(gemAvatar)
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to load settings'
         toaster.create({ type: 'error', title: message })
@@ -85,11 +92,17 @@ export function EnhancementsSettingsView() {
         setBulkDeleteEnabled(enabled)
       }
     })
+    const unwatchGemAvatar = enableGemAvatar.watch((enabled) => {
+      if (isMounted) {
+        setGemAvatarEnabled(enabled)
+      }
+    })
 
     return () => {
       isMounted = false
       unwatchChatOutline()
       unwatchBulkDelete()
+      unwatchGemAvatar()
     }
   }, [])
 
@@ -105,6 +118,15 @@ export function EnhancementsSettingsView() {
   const updateBulkDeleteEnabled = async (enabled: boolean) => {
     try {
       await enableBulkDelete.setValue(enabled)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update setting'
+      toaster.create({ type: 'error', title: message })
+    }
+  }
+
+  const updateGemAvatarEnabled = async (enabled: boolean) => {
+    try {
+      await enableGemAvatar.setValue(enabled)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to update setting'
       toaster.create({ type: 'error', title: message })
@@ -135,6 +157,13 @@ export function EnhancementsSettingsView() {
               checked={bulkDeleteEnabled}
               disabled={isLoading}
               onCheckedChange={(enabled) => void updateBulkDeleteEnabled(enabled)}
+            />
+            <FeatureToggleCard
+              title={t('settings.enhancements.gemAvatar.title')}
+              description={t('settings.enhancements.gemAvatar.description')}
+              checked={gemAvatarEnabled}
+              disabled={isLoading}
+              onCheckedChange={(enabled) => void updateGemAvatarEnabled(enabled)}
             />
           </Stack>
         </Container>

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -5,6 +5,7 @@
 
 import Dexie, { type Table } from 'dexie'
 
+import type { GemAvatarAssetRow } from '@/domain/gem-avatar/types'
 import type { QuickFollowIconKey } from '@/domain/quick-follow/iconKeys'
 import type { ThemeAssetRow } from '@/entrypoints/content/gemini-theme/background/types'
 
@@ -50,6 +51,7 @@ export class GeminiExtensionDB extends Dexie {
   quick_follow_settings!: Table<QuickFollowSettingsRow, string>
   theme_assets!: Table<ThemeAssetRow, string>
   notification_audio_assets!: Table<NotificationAudioAssetRow, string>
+  gem_avatar_assets!: Table<GemAvatarAssetRow, string>
 
   constructor() {
     super('gemini_extension')
@@ -82,6 +84,18 @@ export class GeminiExtensionDB extends Dexie {
         quick_follow_settings: 'id',
         theme_assets: 'id, feature, updatedAt',
         notification_audio_assets: 'id, updatedAt'
+      })
+      .upgrade(() => {
+        // no-op: existing installations do not require data migration
+      })
+    this.version(5)
+      .stores({
+        chain_prompts: 'id, name, createdAt, updatedAt',
+        quick_follow_prompts: 'id, updatedAt',
+        quick_follow_settings: 'id',
+        theme_assets: 'id, feature, updatedAt',
+        notification_audio_assets: 'id, updatedAt',
+        gem_avatar_assets: 'gemId, updatedAt'
       })
       .upgrade(() => {
         // no-op: existing installations do not require data migration

--- a/src/data/repositories/gemAvatarRepository.test.ts
+++ b/src/data/repositories/gemAvatarRepository.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockDeleteGemAvatarAsset,
+  mockGetGemAvatarByGemId,
+  mockPutGemAvatarAsset,
+} = vi.hoisted(() => ({
+  mockDeleteGemAvatarAsset: vi.fn(),
+  mockGetGemAvatarByGemId: vi.fn(),
+  mockPutGemAvatarAsset: vi.fn(),
+}))
+
+vi.mock('../sources', () => ({
+  localDexieDataSource: {
+    deleteGemAvatarAsset: mockDeleteGemAvatarAsset,
+    getGemAvatarByGemId: mockGetGemAvatarByGemId,
+    putGemAvatarAsset: mockPutGemAvatarAsset,
+  },
+}))
+
+import {
+  gemAvatarRepository,
+  GemAvatarError,
+  validateGemAvatarFile,
+} from './gemAvatarRepository'
+import { GEM_AVATAR_FILE_SIZE_LIMIT } from '@/domain/gem-avatar/types'
+
+describe('gemAvatarRepository', () => {
+  const createObjectURLMock = vi.fn()
+  const revokeObjectURLMock = vi.fn()
+
+  beforeEach(() => {
+    mockDeleteGemAvatarAsset.mockReset()
+    mockGetGemAvatarByGemId.mockReset()
+    mockPutGemAvatarAsset.mockReset()
+    createObjectURLMock.mockReset()
+    revokeObjectURLMock.mockReset()
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: createObjectURLMock,
+      configurable: true,
+      writable: true,
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: revokeObjectURLMock,
+      configurable: true,
+      writable: true,
+    })
+    gemAvatarRepository.revokeActiveObjectUrl()
+  })
+
+  it('validates file type and size', () => {
+    const invalidType = new File(['x'], 'a.gif', { type: 'image/gif' })
+    expect(() => validateGemAvatarFile(invalidType)).toThrow(GemAvatarError)
+
+    const oversized = new File(
+      [new Uint8Array(GEM_AVATAR_FILE_SIZE_LIMIT + 1)],
+      'a.png',
+      { type: 'image/png' },
+    )
+    expect(() => validateGemAvatarFile(oversized)).toThrow(GemAvatarError)
+
+    const valid = new File(['ok'], 'a.webp', { type: 'image/webp' })
+    expect(() => validateGemAvatarFile(valid)).not.toThrow()
+  })
+
+  it('saves a prepared avatar by Gem ID', async () => {
+    mockGetGemAvatarByGemId.mockResolvedValue(undefined)
+    mockPutGemAvatarAsset.mockImplementation(async (row) => row)
+
+    await gemAvatarRepository.savePrepared('gem-1', {
+      mimeType: 'image/webp',
+      size: 10,
+      blob: new Blob(['avatar'], { type: 'image/webp' }),
+      width: 256,
+      height: 256,
+    })
+
+    expect(mockPutGemAvatarAsset).toHaveBeenCalledWith(expect.objectContaining({
+      gemId: 'gem-1',
+      mimeType: 'image/webp',
+      size: 10,
+      width: 256,
+      height: 256,
+    }))
+  })
+
+  it('reuses and revokes the active object URL', async () => {
+    mockGetGemAvatarByGemId.mockResolvedValue({
+      gemId: 'gem-1',
+      mimeType: 'image/webp',
+      size: 10,
+      blob: new Blob(['avatar'], { type: 'image/webp' }),
+      width: 256,
+      height: 256,
+      createdAt: '2026-06-20T00:00:00.000Z',
+      updatedAt: '2026-06-20T00:00:00.000Z',
+    })
+    createObjectURLMock.mockReturnValueOnce('blob:gem-1')
+
+    const first = await gemAvatarRepository.resolveObjectUrl('gem-1')
+    const second = await gemAvatarRepository.resolveObjectUrl('gem-1')
+
+    expect(first).toBe('blob:gem-1')
+    expect(second).toBe('blob:gem-1')
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+
+    gemAvatarRepository.revokeActiveObjectUrl()
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:gem-1')
+  })
+
+  it('deletes an avatar and revokes the matching active object URL', async () => {
+    mockGetGemAvatarByGemId.mockResolvedValue({
+      gemId: 'gem-1',
+      mimeType: 'image/webp',
+      size: 10,
+      blob: new Blob(['avatar'], { type: 'image/webp' }),
+      width: 256,
+      height: 256,
+      createdAt: '2026-06-20T00:00:00.000Z',
+      updatedAt: '2026-06-20T00:00:00.000Z',
+    })
+    createObjectURLMock.mockReturnValueOnce('blob:gem-1')
+
+    await gemAvatarRepository.resolveObjectUrl('gem-1')
+    await gemAvatarRepository.deleteByGemId('gem-1')
+
+    expect(mockDeleteGemAvatarAsset).toHaveBeenCalledWith('gem-1')
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:gem-1')
+  })
+})

--- a/src/data/repositories/gemAvatarRepository.ts
+++ b/src/data/repositories/gemAvatarRepository.ts
@@ -1,0 +1,257 @@
+import { z } from 'zod'
+
+import {
+  GEM_AVATAR_FILE_SIZE_LIMIT,
+  GEM_AVATAR_OUTPUT_MIME_TYPE,
+  GEM_AVATAR_OUTPUT_QUALITY,
+  GEM_AVATAR_OUTPUT_SIZE,
+  isAllowedGemAvatarMimeType,
+  type GemAvatarAsset,
+  type GemAvatarAssetRow,
+  type GemAvatarMimeType,
+  type PreparedGemAvatarAsset,
+} from '@/domain/gem-avatar/types'
+
+import { localDexieDataSource } from '../sources'
+
+type GemAvatarErrorCode =
+  | 'invalid-gem-id'
+  | 'invalid-file-type'
+  | 'file-too-large'
+  | 'image-load-failed'
+  | 'canvas-unavailable'
+  | 'image-encode-failed'
+
+export class GemAvatarError extends Error {
+  code: GemAvatarErrorCode
+
+  constructor(code: GemAvatarErrorCode, message: string) {
+    super(message)
+    this.code = code
+  }
+}
+
+const GemIdSchema = z.string().trim().min(1)
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function parseGemId(gemId: string): string {
+  const parsed = GemIdSchema.safeParse(gemId)
+  if (!parsed.success) {
+    throw new GemAvatarError('invalid-gem-id', 'Gem ID is required')
+  }
+  return parsed.data
+}
+
+function rowToDomain(row: GemAvatarAssetRow): GemAvatarAsset {
+  return row
+}
+
+function revokeObjectUrl(url: string | null): void {
+  if (!url) return
+  try {
+    URL.revokeObjectURL(url)
+  } catch (error) {
+    console.warn('[GemAvatar] Failed to revoke object URL:', error)
+  }
+}
+
+function validateGemAvatarFile(
+  file: File,
+): asserts file is File & { type: GemAvatarMimeType } {
+  if (!isAllowedGemAvatarMimeType(file.type)) {
+    throw new GemAvatarError(
+      'invalid-file-type',
+      `Unsupported file type: ${file.type}`,
+    )
+  }
+  if (file.size > GEM_AVATAR_FILE_SIZE_LIMIT) {
+    throw new GemAvatarError(
+      'file-too-large',
+      `File size exceeds ${GEM_AVATAR_FILE_SIZE_LIMIT} bytes`,
+    )
+  }
+}
+
+async function loadImageFromFile(file: File): Promise<HTMLImageElement> {
+  if (typeof Image === 'undefined') {
+    throw new GemAvatarError('image-load-failed', 'Image API is unavailable')
+  }
+
+  const objectUrl = URL.createObjectURL(file)
+  try {
+    return await new Promise<HTMLImageElement>((resolve, reject) => {
+      const image = new Image()
+      image.onload = () => resolve(image)
+      image.onerror = () => reject(
+        new GemAvatarError('image-load-failed', 'Image loading failed'),
+      )
+      image.src = objectUrl
+    })
+  } finally {
+    URL.revokeObjectURL(objectUrl)
+  }
+}
+
+async function encodeCanvas(canvas: HTMLCanvasElement): Promise<Blob> {
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new GemAvatarError(
+            'image-encode-failed',
+            'Image encoding failed',
+          ))
+          return
+        }
+        resolve(blob)
+      },
+      GEM_AVATAR_OUTPUT_MIME_TYPE,
+      GEM_AVATAR_OUTPUT_QUALITY,
+    )
+  })
+}
+
+async function normalizeGemAvatarFile(
+  file: File & { type: GemAvatarMimeType },
+): Promise<PreparedGemAvatarAsset> {
+  const image = await loadImageFromFile(file)
+  const width = image.naturalWidth || image.width
+  const height = image.naturalHeight || image.height
+  const sourceSize = Math.min(width, height)
+
+  if (!sourceSize) {
+    throw new GemAvatarError('image-load-failed', 'Image has no dimensions')
+  }
+
+  const canvas = document.createElement('canvas')
+  canvas.width = GEM_AVATAR_OUTPUT_SIZE
+  canvas.height = GEM_AVATAR_OUTPUT_SIZE
+  const context = canvas.getContext('2d')
+
+  if (!context) {
+    throw new GemAvatarError('canvas-unavailable', 'Canvas is unavailable')
+  }
+
+  const sourceX = Math.max(0, Math.floor((width - sourceSize) / 2))
+  const sourceY = Math.max(0, Math.floor((height - sourceSize) / 2))
+  context.drawImage(
+    image,
+    sourceX,
+    sourceY,
+    sourceSize,
+    sourceSize,
+    0,
+    0,
+    GEM_AVATAR_OUTPUT_SIZE,
+    GEM_AVATAR_OUTPUT_SIZE,
+  )
+
+  const blob = await encodeCanvas(canvas)
+
+  return {
+    mimeType: GEM_AVATAR_OUTPUT_MIME_TYPE,
+    size: blob.size,
+    blob,
+    width: GEM_AVATAR_OUTPUT_SIZE,
+    height: GEM_AVATAR_OUTPUT_SIZE,
+  }
+}
+
+export interface IGemAvatarRepository {
+  getByGemId(gemId: string): Promise<GemAvatarAsset | undefined>
+  prepare(file: File): Promise<PreparedGemAvatarAsset>
+  savePrepared(gemId: string, prepared: PreparedGemAvatarAsset): Promise<GemAvatarAsset>
+  upsert(gemId: string, file: File): Promise<GemAvatarAsset>
+  deleteByGemId(gemId: string): Promise<void>
+  resolveObjectUrl(gemId: string): Promise<string | null>
+  revokeActiveObjectUrl(): void
+}
+
+class GemAvatarRepository implements IGemAvatarRepository {
+  private activeGemId: string | null = null
+  private activeObjectUrl: string | null = null
+
+  async getByGemId(gemId: string): Promise<GemAvatarAsset | undefined> {
+    const parsedGemId = parseGemId(gemId)
+    const row = await localDexieDataSource.getGemAvatarByGemId(parsedGemId)
+    return row ? rowToDomain(row) : undefined
+  }
+
+  async prepare(file: File): Promise<PreparedGemAvatarAsset> {
+    validateGemAvatarFile(file)
+    return await normalizeGemAvatarFile(file)
+  }
+
+  async savePrepared(
+    gemId: string,
+    prepared: PreparedGemAvatarAsset,
+  ): Promise<GemAvatarAsset> {
+    const parsedGemId = parseGemId(gemId)
+    const existing = await localDexieDataSource.getGemAvatarByGemId(parsedGemId)
+    const timestamp = nowIso()
+    const row: GemAvatarAssetRow = {
+      gemId: parsedGemId,
+      mimeType: prepared.mimeType,
+      size: prepared.size,
+      blob: prepared.blob,
+      width: prepared.width,
+      height: prepared.height,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+    }
+
+    if (this.activeGemId === parsedGemId) {
+      this.revokeActiveObjectUrl()
+    }
+
+    await localDexieDataSource.putGemAvatarAsset(row)
+    return rowToDomain(row)
+  }
+
+  async upsert(gemId: string, file: File): Promise<GemAvatarAsset> {
+    const prepared = await this.prepare(file)
+    return await this.savePrepared(gemId, prepared)
+  }
+
+  async deleteByGemId(gemId: string): Promise<void> {
+    const parsedGemId = parseGemId(gemId)
+
+    if (this.activeGemId === parsedGemId) {
+      this.revokeActiveObjectUrl()
+    }
+
+    await localDexieDataSource.deleteGemAvatarAsset(parsedGemId)
+  }
+
+  async resolveObjectUrl(gemId: string): Promise<string | null> {
+    const parsedGemId = parseGemId(gemId)
+
+    if (this.activeGemId === parsedGemId && this.activeObjectUrl) {
+      return this.activeObjectUrl
+    }
+
+    this.revokeActiveObjectUrl()
+
+    const asset = await this.getByGemId(parsedGemId)
+    if (!asset) {
+      return null
+    }
+
+    const objectUrl = URL.createObjectURL(asset.blob)
+    this.activeGemId = parsedGemId
+    this.activeObjectUrl = objectUrl
+    return objectUrl
+  }
+
+  revokeActiveObjectUrl(): void {
+    revokeObjectUrl(this.activeObjectUrl)
+    this.activeGemId = null
+    this.activeObjectUrl = null
+  }
+}
+
+export const gemAvatarRepository = new GemAvatarRepository()
+export { validateGemAvatarFile }

--- a/src/data/repositories/index.ts
+++ b/src/data/repositories/index.ts
@@ -1,4 +1,4 @@
 export { chainPromptRepository, type IChainPromptRepository } from './chainPromptRepository'
+export { gemAvatarRepository, type IGemAvatarRepository } from './gemAvatarRepository'
 export { quickFollowRepository, type IQuickFollowRepository } from './quickFollowRepository'
-
 

--- a/src/data/sources/LocalDexieDataSource.ts
+++ b/src/data/sources/LocalDexieDataSource.ts
@@ -9,6 +9,7 @@ import {
   type QuickFollowPromptRow,
   type QuickFollowSettingsRow
 } from '../db'
+import type { GemAvatarAssetRow } from '@/domain/gem-avatar/types'
 
 export class LocalDexieDataSource {
   async getAllChainPrompts(): Promise<ChainPromptRow[]> {
@@ -98,8 +99,19 @@ export class LocalDexieDataSource {
     await db.quick_follow_settings.put(next)
     return next
   }
+
+  async getGemAvatarByGemId(gemId: string): Promise<GemAvatarAssetRow | undefined> {
+    return await db.gem_avatar_assets.get(gemId)
+  }
+
+  async putGemAvatarAsset(data: GemAvatarAssetRow): Promise<GemAvatarAssetRow> {
+    await db.gem_avatar_assets.put(data)
+    return data
+  }
+
+  async deleteGemAvatarAsset(gemId: string): Promise<void> {
+    await db.gem_avatar_assets.delete(gemId)
+  }
 }
 
 export const localDexieDataSource = new LocalDexieDataSource()
-
-

--- a/src/domain/gem-avatar/types.ts
+++ b/src/domain/gem-avatar/types.ts
@@ -1,0 +1,49 @@
+export const GEM_AVATAR_FILE_SIZE_LIMIT = 3 * 1024 * 1024
+export const GEM_AVATAR_OUTPUT_SIZE = 256
+export const GEM_AVATAR_OUTPUT_MIME_TYPE = 'image/webp'
+export const GEM_AVATAR_OUTPUT_QUALITY = 0.9
+
+export const ALLOWED_GEM_AVATAR_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+] as const
+
+export type GemAvatarMimeType =
+  (typeof ALLOWED_GEM_AVATAR_MIME_TYPES)[number]
+
+export interface GemAvatarAssetRow {
+  gemId: string
+  mimeType: GemAvatarMimeType
+  size: number
+  blob: Blob
+  width?: number
+  height?: number
+  createdAt: string
+  updatedAt: string
+}
+
+export type GemAvatarAsset = GemAvatarAssetRow
+
+export interface PreparedGemAvatarAsset {
+  mimeType: GemAvatarMimeType
+  size: number
+  blob: Blob
+  width: number
+  height: number
+}
+
+export type GemAvatarPage =
+  | { kind: 'create' }
+  | { kind: 'edit'; gemId: string }
+  | { kind: 'list' }
+  | { kind: 'chat'; gemId: string; chatId?: string }
+  | { kind: 'other' }
+
+export function isAllowedGemAvatarMimeType(
+  mimeType: string,
+): mimeType is GemAvatarMimeType {
+  return (ALLOWED_GEM_AVATAR_MIME_TYPES as readonly string[]).includes(
+    mimeType,
+  )
+}

--- a/src/entrypoints/content/gem-avatar/dom.ts
+++ b/src/entrypoints/content/gem-avatar/dom.ts
@@ -1,4 +1,5 @@
 import {
+  EDIT_PREVIEW_SCROLLER_CLASS,
   INJECTED_ATTR,
   LOGO_AVATAR_CLASS,
   LOGO_AVATAR_CLICKABLE_CLASS,
@@ -223,6 +224,19 @@ export function removeInjectedAvatars(root: ParentNode = document): void {
   root.querySelectorAll(`[${INJECTED_ATTR}="true"]`).forEach((node) => {
     node.remove()
   })
+
+  const cleanupClass = (className: string): void => {
+    if (root instanceof Element && root.classList.contains(className)) {
+      root.classList.remove(className)
+    }
+    root.querySelectorAll(`.${className}`).forEach((element) => {
+      element.classList.remove(className)
+    })
+  }
+
+  cleanupClass('gpk-gem-avatar-anchor')
+  cleanupClass('gpk-gem-avatar-logo-anchor')
+  cleanupClass(EDIT_PREVIEW_SCROLLER_CLASS)
 }
 
 export function ensureMatchingTargets(

--- a/src/entrypoints/content/gem-avatar/dom.ts
+++ b/src/entrypoints/content/gem-avatar/dom.ts
@@ -1,0 +1,237 @@
+import {
+  INJECTED_ATTR,
+  LOGO_AVATAR_CLASS,
+  LOGO_AVATAR_CLICKABLE_CLASS,
+  MESSAGE_AVATAR_CLICKABLE_CLASS,
+  RECENT_CHAT_LOGO_AVATAR_CLASS,
+} from './selectors'
+
+interface LogoAvatarOptions {
+  editGemId?: string
+}
+
+interface MessageAvatarOptions {
+  editGemId?: string
+}
+
+export function findFirstElement(selectors: readonly string[]): Element | null {
+  for (const selector of selectors) {
+    const element = document.querySelector(selector)
+    if (element) return element
+  }
+  return null
+}
+
+export function getImageSource(image: HTMLImageElement | null): string | null {
+  const source = image?.currentSrc || image?.src || image?.getAttribute('src')
+  return source?.trim() || null
+}
+
+function createEditIconSvg(): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('viewBox', '0 0 24 24')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.setAttribute('focusable', 'false')
+
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+  path.setAttribute('fill', 'currentColor')
+  path.setAttribute('d', 'M4 17.46V20h2.54L17.6 8.94l-2.54-2.54L4 17.46Zm15.56-10.48c.59-.59.59-1.54 0-2.12L18.14 3.44a1.5 1.5 0 0 0-2.12 0l-1.1 1.1 2.54 2.54 1.1-1.1Z')
+  svg.append(path)
+  return svg
+}
+
+function createCloseIconSvg(): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('viewBox', '0 0 24 24')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.setAttribute('focusable', 'false')
+
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+  path.setAttribute('fill', 'none')
+  path.setAttribute('stroke', 'currentColor')
+  path.setAttribute('stroke-linecap', 'round')
+  path.setAttribute('stroke-linejoin', 'round')
+  path.setAttribute('stroke-width', '3')
+  path.setAttribute('d', 'M18 6 6 18M6 6l12 12')
+  svg.append(path)
+  return svg
+}
+
+export function createUploaderElement(): HTMLElement {
+  const uploader = document.createElement('gem-avatar-uploader')
+  uploader.className = 'gpk-gem-avatar-uploader'
+  uploader.setAttribute('role', 'button')
+  uploader.setAttribute('tabindex', '0')
+  uploader.setAttribute('aria-label', 'Upload Gem avatar')
+  uploader.append(createEditIconSvg())
+  return uploader
+}
+
+export function createDeleteButton(): HTMLButtonElement {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = 'gpk-gem-avatar-delete'
+  button.setAttribute('aria-label', 'Delete Gem avatar')
+  button.append(createCloseIconSvg())
+  return button
+}
+
+function getGemEditUrl(gemId: string): string {
+  return new URL(`/gems/edit/${encodeURIComponent(gemId)}`, window.location.origin).href
+}
+
+export function setAvatarImage(avatar: HTMLElement, src: string | null): void {
+  let image = avatar.querySelector('img')
+  if (!src) {
+    image?.remove()
+    avatar.removeAttribute('data-gpk-gem-avatar-src')
+    return
+  }
+
+  if (!image) {
+    image = document.createElement('img')
+    image.alt = ''
+    image.decoding = 'async'
+    image.loading = 'lazy'
+    avatar.append(image)
+  }
+
+  if (avatar.getAttribute('data-gpk-gem-avatar-src') !== src) {
+    image.src = src
+    avatar.setAttribute('data-gpk-gem-avatar-src', src)
+  }
+}
+
+export function findDirectInjectedAvatar(
+  target: Element,
+  className: string,
+): HTMLElement | null {
+  return Array.from(target.children).find((child) => (
+    child instanceof HTMLElement && child.classList.contains(className)
+  )) as HTMLElement | null
+}
+
+export function removeDirectInjectedAvatar(target: Element, className: string): void {
+  findDirectInjectedAvatar(target, className)?.remove()
+}
+
+function configureAvatarEditPageInteraction(
+  avatar: HTMLElement,
+  editGemId: string | undefined,
+  clickableClassName: string,
+): void {
+  if (!editGemId) {
+    avatar.classList.remove(clickableClassName)
+    avatar.removeAttribute('role')
+    avatar.removeAttribute('tabindex')
+    avatar.removeAttribute('title')
+    avatar.removeAttribute('aria-label')
+    avatar.setAttribute('aria-hidden', 'true')
+    avatar.onclick = null
+    avatar.onkeydown = null
+    return
+  }
+
+  const openEditPage = (event: Event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    window.open(getGemEditUrl(editGemId), '_blank', 'noopener,noreferrer')
+  }
+
+  avatar.classList.add(clickableClassName)
+  avatar.removeAttribute('aria-hidden')
+  avatar.setAttribute('role', 'link')
+  avatar.setAttribute('tabindex', '0')
+  avatar.setAttribute('title', 'Open Gem editor')
+  avatar.setAttribute('aria-label', 'Open Gem editor')
+  avatar.onclick = openEditPage
+  avatar.onkeydown = (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    openEditPage(event)
+  }
+}
+
+export function ensureMessageAvatar(
+  target: Element,
+  variant: 'user' | 'model',
+  src: string,
+  size: 'normal' | 'compact' = 'normal',
+  options: MessageAvatarOptions = {},
+): void {
+  if (!(target instanceof HTMLElement)) return
+
+  const className = variant === 'user'
+    ? 'gpk-gem-avatar-message-user'
+    : 'gpk-gem-avatar-message-model'
+  const existing = findDirectInjectedAvatar(target, className)
+  const avatar = existing ?? document.createElement('gem-avatar')
+
+  avatar.className = [
+    'gpk-gem-avatar',
+    'gpk-gem-avatar-message',
+    className,
+    size === 'compact' ? 'gpk-gem-avatar-message-compact' : '',
+  ].join(' ')
+  avatar.setAttribute(INJECTED_ATTR, 'true')
+  avatar.setAttribute('aria-hidden', 'true')
+  setAvatarImage(avatar, src)
+  configureAvatarEditPageInteraction(
+    avatar,
+    options.editGemId,
+    MESSAGE_AVATAR_CLICKABLE_CLASS,
+  )
+
+  target.classList.add('gpk-gem-avatar-anchor')
+  if (!existing) {
+    target.append(avatar)
+  }
+}
+
+export function ensureLogoAvatar(
+  target: Element,
+  src: string,
+  className: string,
+  options: LogoAvatarOptions = {},
+): void {
+  if (!(target instanceof HTMLElement)) return
+
+  const existing = findDirectInjectedAvatar(target, LOGO_AVATAR_CLASS)
+  const avatar = existing ?? document.createElement('gem-avatar')
+  const classNames = ['gpk-gem-avatar', LOGO_AVATAR_CLASS, className]
+
+  if (target.closest('recent-chat-list-item')) {
+    classNames.push(RECENT_CHAT_LOGO_AVATAR_CLASS)
+  }
+
+  avatar.className = classNames.join(' ')
+  avatar.setAttribute(INJECTED_ATTR, 'true')
+  avatar.setAttribute('aria-hidden', 'true')
+  setAvatarImage(avatar, src)
+  configureAvatarEditPageInteraction(
+    avatar,
+    options.editGemId,
+    LOGO_AVATAR_CLICKABLE_CLASS,
+  )
+
+  target.classList.add('gpk-gem-avatar-logo-anchor')
+  if (!existing) {
+    target.append(avatar)
+  }
+}
+
+export function removeInjectedAvatars(root: ParentNode = document): void {
+  root.querySelectorAll(`[${INJECTED_ATTR}="true"]`).forEach((node) => {
+    node.remove()
+  })
+}
+
+export function ensureMatchingTargets(
+  scope: ParentNode | Element,
+  selector: string,
+  callback: (element: Element) => void,
+): void {
+  if (scope instanceof Element && scope.matches(selector)) {
+    callback(scope)
+  }
+  scope.querySelectorAll(selector).forEach(callback)
+}

--- a/src/entrypoints/content/gem-avatar/index.test.ts
+++ b/src/entrypoints/content/gem-avatar/index.test.ts
@@ -1,0 +1,576 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockDeleteByGemId,
+  mockGetByGemId,
+  mockPrepare,
+  mockResolveObjectUrl,
+  mockRevokeActiveObjectUrl,
+  mockSavePrepared,
+} = vi.hoisted(() => ({
+  mockDeleteByGemId: vi.fn(),
+  mockGetByGemId: vi.fn(),
+  mockPrepare: vi.fn(),
+  mockResolveObjectUrl: vi.fn(),
+  mockRevokeActiveObjectUrl: vi.fn(),
+  mockSavePrepared: vi.fn(),
+}))
+
+vi.mock('@/data/repositories', () => ({
+  gemAvatarRepository: {
+    deleteByGemId: mockDeleteByGemId,
+    getByGemId: mockGetByGemId,
+    prepare: mockPrepare,
+    resolveObjectUrl: mockResolveObjectUrl,
+    revokeActiveObjectUrl: mockRevokeActiveObjectUrl,
+    savePrepared: mockSavePrepared,
+  },
+}))
+
+import { eventBus } from '@/utils/eventbus'
+import { gemAvatarModule } from './index'
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function setPath(path: string): void {
+  window.history.pushState({}, '', path)
+}
+
+function setupChatDom(): void {
+  document.body.innerHTML = `
+    <sidenav-mavatar-footer>
+      <div class="mavatar-footer-row">
+        <a>
+          <div class="mavatar-container">
+            <img class="mavatar-image" src="https://example.com/user.png">
+          </div>
+        </a>
+      </div>
+    </sidenav-mavatar-footer>
+    <chat-window>
+      <bot-logo></bot-logo>
+      <div id="chat-history">
+        <infinite-scroller data-test-id="chat-history-container">
+          <div class="conversation-container">
+            <user-query>
+              <user-query-content>
+                <div class="user-query-container"></div>
+              </user-query-content>
+            </user-query>
+            <model-response>
+              <response-container>
+                <div class="response-container"></div>
+              </response-container>
+            </model-response>
+          </div>
+        </infinite-scroller>
+      </div>
+    </chat-window>
+  `
+}
+
+function createConversation(): HTMLElement {
+  const conversation = document.createElement('div')
+  conversation.className = 'conversation-container'
+  conversation.innerHTML = `
+    <user-query>
+      <user-query-content>
+        <div class="user-query-container"></div>
+      </user-query-content>
+    </user-query>
+    <model-response>
+      <response-container>
+        <div class="response-container"></div>
+      </response-container>
+    </model-response>
+  `
+  return conversation
+}
+
+describe('gemAvatarModule', () => {
+  beforeEach(() => {
+    gemAvatarModule.stop()
+    mockDeleteByGemId.mockReset()
+    mockPrepare.mockReset()
+    mockGetByGemId.mockReset()
+    mockResolveObjectUrl.mockReset()
+    mockRevokeActiveObjectUrl.mockReset()
+    mockSavePrepared.mockReset()
+    mockResolveObjectUrl.mockResolvedValue('blob:gem-avatar')
+    mockGetByGemId.mockResolvedValue(undefined)
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      value: (callback: FrameRequestCallback) => window.setTimeout(() => callback(0), 0),
+      configurable: true,
+      writable: true,
+    })
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      value: (id: number) => window.clearTimeout(id),
+      configurable: true,
+      writable: true,
+    })
+    Object.defineProperty(globalThis, 'requestAnimationFrame', {
+      value: window.requestAnimationFrame,
+      configurable: true,
+      writable: true,
+    })
+    Object.defineProperty(globalThis, 'cancelAnimationFrame', {
+      value: window.cancelAnimationFrame,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  it('injects chat avatars into the initial infinite-scroller content and header', async () => {
+    setPath('/gem/gem-1/chat-1')
+    setupChatDom()
+
+    gemAvatarModule.start()
+    await flush()
+
+    expect(document.querySelector('bot-logo gem-avatar.gpk-gem-avatar-header img')?.getAttribute('src'))
+      .toBe('blob:gem-avatar')
+    expect(document.querySelector('user-query-content > div.user-query-container gem-avatar.gpk-gem-avatar-message-user img')?.getAttribute('src'))
+      .toBe('https://example.com/user.png')
+    expect(document.querySelector('response-container > div.response-container gem-avatar.gpk-gem-avatar-message-model img')?.getAttribute('src'))
+      .toBe('blob:gem-avatar')
+  })
+
+  it('opens the Gem editor from the chat-page Gem logo avatar', async () => {
+    setPath('/gem/gem-1/chat-1')
+    setupChatDom()
+    const openMock = vi.fn()
+    Object.defineProperty(window, 'open', {
+      value: openMock,
+      configurable: true,
+      writable: true,
+    })
+
+    gemAvatarModule.start()
+    await flush()
+
+    const avatar = document.querySelector<HTMLElement>('bot-logo gem-avatar.gpk-gem-avatar-header')!
+    avatar.click()
+
+    expect(avatar.classList.contains('gpk-gem-avatar-logo-clickable'))
+      .toBe(true)
+    expect(avatar.getAttribute('role'))
+      .toBe('link')
+    expect(avatar.getAttribute('aria-label'))
+      .toBe('Open Gem editor')
+    expect(openMock).toHaveBeenCalledWith(
+      'http://localhost:3000/gems/edit/gem-1',
+      '_blank',
+      'noopener,noreferrer',
+    )
+  })
+
+  it('opens the Gem editor from the chat-page model message avatar', async () => {
+    setPath('/gem/gem-1/chat-1')
+    setupChatDom()
+    const openMock = vi.fn()
+    Object.defineProperty(window, 'open', {
+      value: openMock,
+      configurable: true,
+      writable: true,
+    })
+
+    gemAvatarModule.start()
+    await flush()
+
+    const avatar = document.querySelector<HTMLElement>(
+      'response-container > div.response-container gem-avatar.gpk-gem-avatar-message-model',
+    )!
+    avatar.click()
+
+    expect(avatar.classList.contains('gpk-gem-avatar-message-clickable'))
+      .toBe(true)
+    expect(avatar.getAttribute('role'))
+      .toBe('link')
+    expect(avatar.getAttribute('aria-label'))
+      .toBe('Open Gem editor')
+    expect(openMock).toHaveBeenCalledWith(
+      'http://localhost:3000/gems/edit/gem-1',
+      '_blank',
+      'noopener,noreferrer',
+    )
+  })
+
+  it('applies recent-chat-list-item logo radius class outside edit pages', async () => {
+    setPath('/gem/gem-1')
+    document.body.innerHTML = `
+      <chat-window>
+        <recent-chat-list-item>
+          <bot-logo style="--bot-logo-size: 32px"></bot-logo>
+        </recent-chat-list-item>
+        <div id="chat-history">
+          <infinite-scroller data-test-id="chat-history-container"></infinite-scroller>
+        </div>
+      </chat-window>
+    `
+
+    gemAvatarModule.start()
+    await flush()
+
+    const avatar = document.querySelector('recent-chat-list-item bot-logo gem-avatar')
+
+    expect(avatar?.classList.contains('gpk-gem-avatar-header'))
+      .toBe(true)
+    expect(avatar?.classList.contains('gpk-gem-avatar-recent-chat-logo'))
+      .toBe(true)
+  })
+
+  it('observes added chat messages inside infinite-scroller only', async () => {
+    setPath('/gem/gem-1')
+    setupChatDom()
+    const scroller = document.querySelector('infinite-scroller')!
+
+    gemAvatarModule.start()
+    await flush()
+
+    const insideConversation = createConversation()
+    scroller.append(insideConversation)
+    await flush()
+    await flush()
+
+    expect(insideConversation.querySelector('gem-avatar.gpk-gem-avatar-message-model img')?.getAttribute('src'))
+      .toBe('blob:gem-avatar')
+
+    const outsideConversation = createConversation()
+    document.body.append(outsideConversation)
+    await flush()
+    await flush()
+
+    expect(outsideConversation.querySelector('gem-avatar.gpk-gem-avatar-message-model img'))
+      .toBeNull()
+  })
+
+  it('refreshes chat observer when same-Gem route navigation replaces chat DOM', async () => {
+    setPath('/gem/gem-1')
+    setupChatDom()
+
+    gemAvatarModule.start()
+    await flush()
+
+    const oldChatWindow = document.querySelector('chat-window')!
+
+    setPath('/gem/gem-1/chat-1')
+    await eventBus.emit('urlchange', {
+      url: window.location.href,
+      timestamp: Date.now(),
+    })
+    await flush()
+
+    oldChatWindow.remove()
+    document.body.insertAdjacentHTML('beforeend', `
+      <chat-window>
+        <bot-logo></bot-logo>
+        <div id="chat-history">
+          <infinite-scroller data-test-id="chat-history-container">
+            <div class="conversation-container">
+              <user-query>
+                <user-query-content>
+                  <div class="user-query-container"></div>
+                </user-query-content>
+              </user-query>
+              <model-response>
+                <response-container>
+                  <div class="response-container"></div>
+                </response-container>
+              </model-response>
+            </div>
+          </infinite-scroller>
+        </div>
+      </chat-window>
+    `)
+
+    await wait(300)
+    await flush()
+
+    expect(document.querySelector('response-container > div.response-container gem-avatar.gpk-gem-avatar-message-model img')?.getAttribute('src'))
+      .toBe('blob:gem-avatar')
+    expect(document.querySelector('user-query-content > div.user-query-container gem-avatar.gpk-gem-avatar-message-user img')?.getAttribute('src'))
+      .toBe('https://example.com/user.png')
+  })
+
+  it('persists pending create-page avatar when route changes to edit page', async () => {
+    setPath('/gems/create')
+    document.body.innerHTML = `
+      <bots-creation-window>
+        <div class="title-container">
+          <bot-logo></bot-logo>
+        </div>
+      </bots-creation-window>
+    `
+    const prepared = {
+      mimeType: 'image/webp' as const,
+      size: 10,
+      blob: new Blob(['avatar'], { type: 'image/webp' }),
+      width: 256,
+      height: 256,
+    }
+    mockPrepare.mockResolvedValue(prepared)
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:pending-avatar'),
+      configurable: true,
+      writable: true,
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      configurable: true,
+      writable: true,
+    })
+
+    gemAvatarModule.start()
+    await flush()
+
+    const input = document.querySelector<HTMLInputElement>('.gpk-gem-avatar-file-input')!
+    const file = new File(['avatar'], 'avatar.png', { type: 'image/png' })
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    })
+    input.dispatchEvent(new Event('change'))
+    await flush()
+
+    setPath('/gems/edit/gem-new')
+    await eventBus.emit('urlchange', {
+      url: window.location.href,
+      timestamp: Date.now(),
+    })
+    await flush()
+
+    expect(mockSavePrepared).toHaveBeenCalledWith('gem-new', prepared)
+  })
+
+  it('injects compact avatars into edit-page chat previews and recent chat logos', async () => {
+    setPath('/gems/edit/gem-1')
+    document.body.innerHTML = `
+      <sidenav-mavatar-footer>
+        <div class="mavatar-footer-row">
+          <a>
+            <div class="mavatar-container">
+              <img class="mavatar-image" src="https://example.com/user.png">
+            </div>
+          </a>
+        </div>
+      </sidenav-mavatar-footer>
+      <bots-creation-window>
+        <div class="title-container">
+          <bot-logo></bot-logo>
+        </div>
+        <infinite-scroller>
+          <recent-chat-list-item>
+            <bot-logo style="--bot-logo-size: 32px"></bot-logo>
+          </recent-chat-list-item>
+          <bot-info-card>
+            <div class="bot-info-container">
+              <bot-logo></bot-logo>
+            </div>
+          </bot-info-card>
+          <div class="conversation-container">
+            <user-query>
+              <user-query-content>
+                <div class="user-query-container"></div>
+              </user-query-content>
+            </user-query>
+            <model-response>
+              <response-container>
+                <div class="response-container"></div>
+              </response-container>
+            </model-response>
+          </div>
+        </infinite-scroller>
+      </bots-creation-window>
+    `
+
+    gemAvatarModule.start()
+    await flush()
+
+    expect(document.querySelector('recent-chat-list-item bot-logo gem-avatar')?.classList.contains('gpk-gem-avatar-recent-chat-logo'))
+      .toBe(true)
+    expect(document.querySelector('bot-info-card div.bot-info-container > bot-logo gem-avatar')?.classList.contains('gpk-gem-avatar-edit-preview-logo'))
+      .toBe(true)
+    expect(document.querySelector('bots-creation-window infinite-scroller')?.classList.contains('gpk-gem-avatar-edit-preview-scroller'))
+      .toBe(true)
+    expect(document.querySelector('bots-creation-window infinite-scroller .gpk-gem-avatar-message-user')?.classList.contains('gpk-gem-avatar-message-compact'))
+      .toBe(true)
+    expect(document.querySelector('bots-creation-window infinite-scroller .gpk-gem-avatar-message-model')?.classList.contains('gpk-gem-avatar-message-compact'))
+      .toBe(true)
+  })
+
+  it('deletes the stored edit-page avatar from the hover control', async () => {
+    setPath('/gems/edit/gem-1')
+    document.body.innerHTML = `
+      <bots-creation-window>
+        <div class="title-container">
+          <bot-logo></bot-logo>
+        </div>
+        <infinite-scroller>
+          <bot-info-card>
+            <div class="bot-info-container">
+              <bot-logo></bot-logo>
+            </div>
+          </bot-info-card>
+          <div class="conversation-container">
+            <model-response>
+              <response-container>
+                <div class="response-container"></div>
+              </response-container>
+            </model-response>
+          </div>
+        </infinite-scroller>
+      </bots-creation-window>
+    `
+    mockDeleteByGemId.mockResolvedValue(undefined)
+
+    gemAvatarModule.start()
+    await flush()
+
+    const deleteButton = document.querySelector<HTMLButtonElement>('.gpk-gem-avatar-delete')!
+    expect(deleteButton.hidden).toBe(false)
+    expect(deleteButton.textContent).toBe('')
+    expect(deleteButton.querySelector('svg')).not.toBeNull()
+    expect(document.querySelector('bot-info-card bot-logo gem-avatar.gpk-gem-avatar-edit-preview-logo'))
+      .not.toBeNull()
+    expect(document.querySelector('response-container > div.response-container gem-avatar.gpk-gem-avatar-message-model'))
+      .not.toBeNull()
+    expect(document.querySelector('bots-creation-window infinite-scroller')?.classList.contains('gpk-gem-avatar-edit-preview-scroller'))
+      .toBe(true)
+
+    deleteButton.click()
+    await flush()
+
+    expect(mockDeleteByGemId).toHaveBeenCalledWith('gem-1')
+    expect(document.querySelector('.gpk-gem-avatar-delete')?.hasAttribute('hidden'))
+      .toBe(true)
+    expect(document.querySelector('bot-info-card bot-logo gem-avatar.gpk-gem-avatar-edit-preview-logo'))
+      .toBeNull()
+    expect(document.querySelector('response-container > div.response-container gem-avatar.gpk-gem-avatar-message-model'))
+      .toBeNull()
+    expect(document.querySelector('bots-creation-window infinite-scroller')?.classList.contains('gpk-gem-avatar-edit-preview-scroller'))
+      .toBe(false)
+  })
+
+  it('hides the edit-page avatar delete control when there is no avatar', async () => {
+    setPath('/gems/edit/gem-1')
+    document.body.innerHTML = `
+      <bots-creation-window>
+        <div class="title-container">
+          <bot-logo></bot-logo>
+        </div>
+      </bots-creation-window>
+    `
+    mockResolveObjectUrl.mockResolvedValueOnce(null)
+
+    gemAvatarModule.start()
+    await flush()
+
+    expect(document.querySelector<HTMLButtonElement>('.gpk-gem-avatar-delete')?.hidden)
+      .toBe(true)
+  })
+
+  it('injects stored avatars into Gem list rows by href Gem ID', async () => {
+    setPath('/gems/view')
+    document.body.innerHTML = `
+      <div class="bots-section-container">
+        <bot-list-row>
+          <div class="bot-list-row-container">
+            <a class="bot-row" href="/gem/bed3427bd579">
+              <bot-logo></bot-logo>
+            </a>
+          </div>
+        </bot-list-row>
+        <bot-list-row>
+          <div class="bot-list-row-container">
+            <a class="bot-row" href="/gem/no-avatar">
+              <bot-logo></bot-logo>
+            </a>
+          </div>
+        </bot-list-row>
+      </div>
+    `
+    const createObjectURLMock = vi.fn(() => 'blob:list-avatar')
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: createObjectURLMock,
+      configurable: true,
+      writable: true,
+    })
+    mockGetByGemId.mockImplementation(async (gemId: string) => {
+      if (gemId !== 'bed3427bd579') return undefined
+      return {
+        gemId,
+        mimeType: 'image/webp',
+        size: 10,
+        blob: new Blob(['avatar'], { type: 'image/webp' }),
+        width: 256,
+        height: 256,
+        createdAt: '2026-06-20T00:00:00.000Z',
+        updatedAt: '2026-06-20T00:00:00.000Z',
+      }
+    })
+
+    gemAvatarModule.start()
+    await flush()
+
+    expect(document.querySelector('a[href="/gem/bed3427bd579"] bot-logo gem-avatar.gpk-gem-avatar-list img')?.getAttribute('src'))
+      .toBe('blob:list-avatar')
+    expect(document.querySelector('a[href="/gem/bed3427bd579"] bot-logo gem-avatar.gpk-gem-avatar-list')?.classList.contains('gpk-gem-avatar-logo'))
+      .toBe(true)
+    expect(document.querySelector('a[href="/gem/no-avatar"] bot-logo gem-avatar.gpk-gem-avatar-list'))
+      .toBeNull()
+  })
+
+  it('revokes Gem list object URLs when leaving list page', async () => {
+    setPath('/gems/view')
+    document.body.innerHTML = `
+      <div class="bots-section-container">
+        <bot-list-row>
+          <div class="bot-list-row-container">
+            <a class="bot-row" href="/gem/bed3427bd579">
+              <bot-logo></bot-logo>
+            </a>
+          </div>
+        </bot-list-row>
+      </div>
+    `
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:list-avatar'),
+      configurable: true,
+      writable: true,
+    })
+    const revokeObjectURLMock = vi.fn()
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: revokeObjectURLMock,
+      configurable: true,
+      writable: true,
+    })
+    mockGetByGemId.mockResolvedValue({
+      gemId: 'bed3427bd579',
+      mimeType: 'image/webp',
+      size: 10,
+      blob: new Blob(['avatar'], { type: 'image/webp' }),
+      width: 256,
+      height: 256,
+      createdAt: '2026-06-20T00:00:00.000Z',
+      updatedAt: '2026-06-20T00:00:00.000Z',
+    })
+
+    gemAvatarModule.start()
+    await flush()
+
+    setPath('/app')
+    await eventBus.emit('urlchange', {
+      url: window.location.href,
+      timestamp: Date.now(),
+    })
+    await flush()
+
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:list-avatar')
+  })
+})

--- a/src/entrypoints/content/gem-avatar/index.test.ts
+++ b/src/entrypoints/content/gem-avatar/index.test.ts
@@ -141,6 +141,36 @@ describe('gemAvatarModule', () => {
       .toBe('blob:gem-avatar')
   })
 
+  it('removes injected avatars and layout classes when stopped, then restores them when restarted', async () => {
+    setPath('/gem/gem-1/chat-1')
+    setupChatDom()
+    const previewScroller = document.createElement('infinite-scroller')
+    previewScroller.classList.add('gpk-gem-avatar-edit-preview-scroller')
+    document.body.append(previewScroller)
+
+    gemAvatarModule.start()
+    await flush()
+
+    gemAvatarModule.stop()
+
+    expect(document.querySelector('[data-gpk-gem-avatar-injected="true"]')).toBeNull()
+    expect(document.querySelector('bot-logo')?.classList.contains('gpk-gem-avatar-logo-anchor'))
+      .toBe(false)
+    expect(document.querySelector('user-query-content > div.user-query-container')?.classList.contains('gpk-gem-avatar-anchor'))
+      .toBe(false)
+    expect(previewScroller.classList.contains('gpk-gem-avatar-edit-preview-scroller'))
+      .toBe(false)
+
+    gemAvatarModule.start()
+    await flush()
+
+    expect(document.querySelector('[data-gpk-gem-avatar-injected="true"]')).not.toBeNull()
+    expect(document.querySelector('bot-logo')?.classList.contains('gpk-gem-avatar-logo-anchor'))
+      .toBe(true)
+    expect(document.querySelector('user-query-content > div.user-query-container')?.classList.contains('gpk-gem-avatar-anchor'))
+      .toBe(true)
+  })
+
   it('opens the Gem editor from the chat-page Gem logo avatar', async () => {
     setPath('/gem/gem-1/chat-1')
     setupChatDom()

--- a/src/entrypoints/content/gem-avatar/index.ts
+++ b/src/entrypoints/content/gem-avatar/index.ts
@@ -1,0 +1,996 @@
+import { gemAvatarRepository } from '@/data/repositories'
+import type {
+  GemAvatarPage,
+  PreparedGemAvatarAsset,
+} from '@/domain/gem-avatar/types'
+import { eventBus } from '@/utils/eventbus'
+
+import { getGemAvatarRouteKey, parseGemAvatarPage } from './route'
+import './style.css'
+
+const INJECTED_ATTR = 'data-gpk-gem-avatar-injected'
+const CHAT_ROOT_SELECTORS = [
+  'chat-window #chat-history infinite-scroller[data-test-id="chat-history-container"]',
+  '#chat-history infinite-scroller',
+  'chat-window',
+] as const
+const HEADER_ROOT_SELECTORS = ['chat-window', 'body'] as const
+const EDIT_ROOT_SELECTORS = ['bots-creation-window', 'body'] as const
+const LIST_ROOT_SELECTORS = ['div.bots-section-container', 'body'] as const
+const EDIT_LOGO_SELECTOR = 'bots-creation-window div.title-container > bot-logo'
+const EDIT_PREVIEW_CHAT_ROOT_SELECTOR = 'bots-creation-window infinite-scroller'
+const EDIT_PREVIEW_LOGO_SELECTOR = `${EDIT_PREVIEW_CHAT_ROOT_SELECTOR} bot-logo`
+const HEADER_LOGO_SELECTOR = 'bot-logo'
+const LIST_ROW_SELECTOR = 'div.bots-section-container bot-list-row'
+const LIST_ROW_LINK_SELECTOR = 'a.bot-row[href^="/gem/"], a.bot-row[href*="/gem/"]'
+const LIST_ROW_LOGO_SELECTOR = 'bot-logo'
+const USER_AVATAR_SELECTOR = 'sidenav-mavatar-footer > div.mavatar-footer-row > a > div.mavatar-container > img.mavatar-image'
+const USER_MESSAGE_TARGET_SELECTOR = 'user-query-content > div.user-query-container'
+const MODEL_MESSAGE_TARGET_SELECTOR = 'response-container > div.response-container'
+const LOGO_AVATAR_CLASS = 'gpk-gem-avatar-logo'
+const LOGO_AVATAR_CLICKABLE_CLASS = 'gpk-gem-avatar-logo-clickable'
+const MESSAGE_AVATAR_CLICKABLE_CLASS = 'gpk-gem-avatar-message-clickable'
+const RECENT_CHAT_LOGO_AVATAR_CLASS = 'gpk-gem-avatar-recent-chat-logo'
+const EDIT_PREVIEW_SCROLLER_CLASS = 'gpk-gem-avatar-edit-preview-scroller'
+const CHAT_RELEVANT_SELECTOR = [
+  '.conversation-container',
+  'user-query',
+  'model-response',
+  USER_MESSAGE_TARGET_SELECTOR,
+  MODEL_MESSAGE_TARGET_SELECTOR,
+].join(',')
+const CHAT_ROOT_RETRY_LIMIT = 20
+const CHAT_ROOT_RETRY_DELAY_MS = 250
+const CHAT_ROUTE_SETTLE_RETRY_LIMIT = 12
+const CHAT_ROUTE_SETTLE_RETRY_DELAY_MS = 250
+
+interface ObserverState {
+  observer: MutationObserver | null
+  root: Element | null
+}
+
+interface LogoAvatarOptions {
+  editGemId?: string
+}
+
+interface MessageAvatarOptions {
+  editGemId?: string
+}
+
+function findFirstElement(selectors: readonly string[]): Element | null {
+  for (const selector of selectors) {
+    const element = document.querySelector(selector)
+    if (element) return element
+  }
+  return null
+}
+
+function describePageForLog(page: GemAvatarPage): string {
+  if (page.kind === 'chat') {
+    return page.chatId
+      ? `chat:${page.gemId}/${page.chatId}`
+      : `chat:${page.gemId}`
+  }
+  if (page.kind === 'edit') {
+    return `edit:${page.gemId}`
+  }
+  return page.kind
+}
+
+function describeElementForLog(element: Element | null): string | null {
+  if (!element) return null
+
+  const tag = element.tagName.toLowerCase()
+  const id = element.id ? `#${element.id}` : ''
+  const testId = element.getAttribute('data-test-id')
+  const testIdText = testId ? `[data-test-id="${testId}"]` : ''
+  return `${tag}${id}${testIdText}`
+}
+
+function logGemAvatar(message: string, details?: Record<string, unknown>): void {
+  if (details) {
+    console.log(`[GemAvatar] ${message}`, details)
+    return
+  }
+  console.log(`[GemAvatar] ${message}`)
+}
+
+function pageUsesSameContext(a: GemAvatarPage, b: GemAvatarPage): boolean {
+  return getGemAvatarRouteKey(a) === getGemAvatarRouteKey(b)
+}
+
+function isCreateOrEditPage(page: GemAvatarPage): boolean {
+  return page.kind === 'create' || page.kind === 'edit'
+}
+
+function getImageSource(image: HTMLImageElement | null): string | null {
+  const source = image?.currentSrc || image?.src || image?.getAttribute('src')
+  return source?.trim() || null
+}
+
+function createEditIconSvg(): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('viewBox', '0 0 24 24')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.setAttribute('focusable', 'false')
+
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+  path.setAttribute('fill', 'currentColor')
+  path.setAttribute('d', 'M4 17.46V20h2.54L17.6 8.94l-2.54-2.54L4 17.46Zm15.56-10.48c.59-.59.59-1.54 0-2.12L18.14 3.44a1.5 1.5 0 0 0-2.12 0l-1.1 1.1 2.54 2.54 1.1-1.1Z')
+  svg.append(path)
+  return svg
+}
+
+function createCloseIconSvg(): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('viewBox', '0 0 24 24')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.setAttribute('focusable', 'false')
+
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+  path.setAttribute('fill', 'none')
+  path.setAttribute('stroke', 'currentColor')
+  path.setAttribute('stroke-linecap', 'round')
+  path.setAttribute('stroke-linejoin', 'round')
+  path.setAttribute('stroke-width', '3')
+  path.setAttribute('d', 'M18 6 6 18M6 6l12 12')
+  svg.append(path)
+  return svg
+}
+
+function createDeleteButton(): HTMLButtonElement {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = 'gpk-gem-avatar-delete'
+  button.setAttribute('aria-label', 'Delete Gem avatar')
+  button.append(createCloseIconSvg())
+  return button
+}
+
+function getGemEditUrl(gemId: string): string {
+  return new URL(`/gems/edit/${encodeURIComponent(gemId)}`, window.location.origin).href
+}
+
+function setAvatarImage(avatar: HTMLElement, src: string | null): void {
+  let image = avatar.querySelector('img')
+  if (!src) {
+    image?.remove()
+    avatar.removeAttribute('data-gpk-gem-avatar-src')
+    return
+  }
+
+  if (!image) {
+    image = document.createElement('img')
+    image.alt = ''
+    image.decoding = 'async'
+    image.loading = 'lazy'
+    avatar.append(image)
+  }
+
+  if (avatar.getAttribute('data-gpk-gem-avatar-src') !== src) {
+    image.src = src
+    avatar.setAttribute('data-gpk-gem-avatar-src', src)
+  }
+}
+
+function removeDirectInjectedAvatar(target: Element, className: string): void {
+  findDirectInjectedAvatar(target, className)?.remove()
+}
+
+function configureAvatarEditPageInteraction(
+  avatar: HTMLElement,
+  editGemId: string | undefined,
+  clickableClassName: string,
+): void {
+  if (!editGemId) {
+    avatar.classList.remove(clickableClassName)
+    avatar.removeAttribute('role')
+    avatar.removeAttribute('tabindex')
+    avatar.removeAttribute('title')
+    avatar.removeAttribute('aria-label')
+    avatar.setAttribute('aria-hidden', 'true')
+    avatar.onclick = null
+    avatar.onkeydown = null
+    return
+  }
+
+  const openEditPage = (event: Event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    window.open(getGemEditUrl(editGemId), '_blank', 'noopener,noreferrer')
+  }
+
+  avatar.classList.add(clickableClassName)
+  avatar.removeAttribute('aria-hidden')
+  avatar.setAttribute('role', 'link')
+  avatar.setAttribute('tabindex', '0')
+  avatar.setAttribute('title', 'Open Gem editor')
+  avatar.setAttribute('aria-label', 'Open Gem editor')
+  avatar.onclick = openEditPage
+  avatar.onkeydown = (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    openEditPage(event)
+  }
+}
+
+function findDirectInjectedAvatar(
+  target: Element,
+  className: string,
+): HTMLElement | null {
+  return Array.from(target.children).find((child) => (
+    child instanceof HTMLElement && child.classList.contains(className)
+  )) as HTMLElement | null
+}
+
+function ensureMessageAvatar(
+  target: Element,
+  variant: 'user' | 'model',
+  src: string,
+  size: 'normal' | 'compact' = 'normal',
+  options: MessageAvatarOptions = {},
+): void {
+  if (!(target instanceof HTMLElement)) return
+
+  const className = variant === 'user'
+    ? 'gpk-gem-avatar-message-user'
+    : 'gpk-gem-avatar-message-model'
+  const existing = findDirectInjectedAvatar(target, className)
+  const avatar = existing ?? document.createElement('gem-avatar')
+
+  avatar.className = [
+    'gpk-gem-avatar',
+    'gpk-gem-avatar-message',
+    className,
+    size === 'compact' ? 'gpk-gem-avatar-message-compact' : '',
+  ].join(' ')
+  avatar.setAttribute(INJECTED_ATTR, 'true')
+  avatar.setAttribute('aria-hidden', 'true')
+  setAvatarImage(avatar, src)
+  configureAvatarEditPageInteraction(
+    avatar,
+    options.editGemId,
+    MESSAGE_AVATAR_CLICKABLE_CLASS,
+  )
+
+  target.classList.add('gpk-gem-avatar-anchor')
+  if (!existing) {
+    target.append(avatar)
+  }
+}
+
+function ensureLogoAvatar(
+  target: Element,
+  src: string,
+  className: string,
+  options: LogoAvatarOptions = {},
+): void {
+  if (!(target instanceof HTMLElement)) return
+
+  const existing = findDirectInjectedAvatar(target, LOGO_AVATAR_CLASS)
+  const avatar = existing ?? document.createElement('gem-avatar')
+  const classNames = ['gpk-gem-avatar', LOGO_AVATAR_CLASS, className]
+
+  if (target.closest('recent-chat-list-item')) {
+    classNames.push(RECENT_CHAT_LOGO_AVATAR_CLASS)
+  }
+
+  avatar.className = classNames.join(' ')
+  avatar.setAttribute(INJECTED_ATTR, 'true')
+  avatar.setAttribute('aria-hidden', 'true')
+  setAvatarImage(avatar, src)
+  configureAvatarEditPageInteraction(
+    avatar,
+    options.editGemId,
+    LOGO_AVATAR_CLICKABLE_CLASS,
+  )
+
+  target.classList.add('gpk-gem-avatar-logo-anchor')
+  if (!existing) {
+    target.append(avatar)
+  }
+}
+
+function getCurrentEditAvatarUrl(
+  page: GemAvatarPage,
+  pendingPreviewUrl: string | null,
+  activeGemAvatarUrl: string | null,
+): string | null {
+  if (page.kind === 'create') {
+    return pendingPreviewUrl
+  }
+  if (page.kind === 'edit') {
+    return pendingPreviewUrl ?? activeGemAvatarUrl
+  }
+  return null
+}
+
+function removeInjectedAvatars(root: ParentNode = document): void {
+  root.querySelectorAll(`[${INJECTED_ATTR}="true"]`).forEach((node) => {
+    node.remove()
+  })
+}
+
+class GemAvatarModule {
+  private isStarted = false
+  private currentPage: GemAvatarPage = { kind: 'other' }
+  private unsubscribeUrlChange: (() => void) | null = null
+  private chatState: ObserverState = { observer: null, root: null }
+  private headerState: ObserverState = { observer: null, root: null }
+  private editState: ObserverState = { observer: null, root: null }
+  private listState: ObserverState = { observer: null, root: null }
+  private pendingAvatar: PreparedGemAvatarAsset | null = null
+  private pendingPreviewUrl: string | null = null
+  private activeGemAvatarUrl: string | null = null
+  private listAvatarUrls = new Map<string, string>()
+  private listCheckedRows = new WeakSet<Element>()
+  private scheduledListRows = new Set<Element>()
+  private scheduledChatScopes = new Set<Element>()
+  private chatFrameId: number | null = null
+  private headerFrameId: number | null = null
+  private editFrameId: number | null = null
+  private listFrameId: number | null = null
+  private chatRootRetryTimer: number | null = null
+  private chatRootRetryAttempts = 0
+  private chatRouteSettleTimer: number | null = null
+  private chatRouteSettleAttempts = 0
+
+  start(): void {
+    if (this.isStarted) return
+
+    this.isStarted = true
+    this.unsubscribeUrlChange = eventBus.on('urlchange', (event) => {
+      logGemAvatar('urlchange received', {
+        eventUrl: event.url,
+        href: window.location.href,
+      })
+      void this.syncToCurrentUrl()
+    })
+    void this.syncToCurrentUrl()
+  }
+
+  stop(): void {
+    if (!this.isStarted) return
+
+    this.unsubscribeUrlChange?.()
+    this.unsubscribeUrlChange = null
+    this.disconnectAllObservers()
+    this.cancelScheduledWork()
+    this.clearPendingAvatar()
+    this.clearActiveGemAvatar()
+    this.clearListAvatarUrls()
+    this.currentPage = { kind: 'other' }
+    this.isStarted = false
+  }
+
+  private async syncToCurrentUrl(): Promise<void> {
+    if (!this.isStarted) return
+
+    const nextPage = parseGemAvatarPage(window.location.href)
+    const sameContext = pageUsesSameContext(this.currentPage, nextPage)
+    const previousPage = this.currentPage
+
+    logGemAvatar('sync route', {
+      previousPage: describePageForLog(previousPage),
+      nextPage: describePageForLog(nextPage),
+      sameContext,
+    })
+
+    if (!sameContext) {
+      this.disconnectAllObservers()
+      this.cancelScheduledWork()
+      removeInjectedAvatars()
+      this.clearActiveGemAvatar()
+      this.clearListAvatarUrls()
+    }
+
+    if (
+      previousPage.kind === 'create'
+      && nextPage.kind === 'edit'
+      && this.pendingAvatar
+    ) {
+      await gemAvatarRepository.savePrepared(nextPage.gemId, this.pendingAvatar)
+      this.clearPendingAvatar()
+    } else if (!isCreateOrEditPage(nextPage)) {
+      this.clearPendingAvatar()
+    }
+
+    this.currentPage = nextPage
+
+    if (nextPage.kind === 'chat') {
+      this.activeGemAvatarUrl = await gemAvatarRepository.resolveObjectUrl(nextPage.gemId)
+      logGemAvatar('chat avatar resolved', {
+        page: describePageForLog(nextPage),
+        hasAvatar: Boolean(this.activeGemAvatarUrl),
+      })
+      if (!this.activeGemAvatarUrl) {
+        removeInjectedAvatars()
+      }
+      this.resetChatRouteSettleRetry()
+      this.installChatObserver()
+      this.scheduleChatRootRetryIfNeeded()
+      this.scheduleChatRouteSettleRetry()
+      this.installHeaderObserver()
+      this.ensureChatAvatars()
+      this.ensureHeaderAvatar()
+      return
+    }
+
+    if (nextPage.kind === 'edit') {
+      this.activeGemAvatarUrl = await gemAvatarRepository.resolveObjectUrl(nextPage.gemId)
+      this.installEditObserver()
+      this.ensureEditAvatar()
+      return
+    }
+
+    if (nextPage.kind === 'create') {
+      this.installEditObserver()
+      this.ensureEditAvatar()
+      return
+    }
+
+    if (nextPage.kind === 'list') {
+      this.installListObserver()
+      this.ensureListAvatars()
+      return
+    }
+
+    removeInjectedAvatars()
+  }
+
+  private installChatObserver(): void {
+    const root = findFirstElement(CHAT_ROOT_SELECTORS)
+    if (!root) {
+      logGemAvatar('chat observer root missing')
+      return
+    }
+    if (this.chatState.root === root && this.chatState.observer) {
+      return
+    }
+
+    this.chatState.observer?.disconnect()
+    const observer = new MutationObserver((mutations) => {
+      const scopes = this.collectChatScopes(mutations)
+      if (scopes.length === 0) return
+      scopes.forEach((scope) => this.scheduledChatScopes.add(scope))
+      this.scheduleChatFlush()
+    })
+    observer.observe(root, { childList: true, subtree: true })
+    this.chatState = { observer, root }
+    this.chatRootRetryAttempts = 0
+    logGemAvatar('chat observer installed', {
+      root: describeElementForLog(root),
+    })
+  }
+
+  private installHeaderObserver(): void {
+    const root = findFirstElement(HEADER_ROOT_SELECTORS)
+    if (!root) return
+    if (this.headerState.root === root && this.headerState.observer) return
+
+    this.headerState.observer?.disconnect()
+    const observer = new MutationObserver((mutations) => {
+      if (!this.mutationsContainElement(mutations, HEADER_LOGO_SELECTOR)) return
+      this.scheduleHeaderFlush()
+    })
+    observer.observe(root, { childList: true, subtree: true })
+    this.headerState = { observer, root }
+  }
+
+  private installEditObserver(): void {
+    const root = findFirstElement(EDIT_ROOT_SELECTORS)
+    if (!root) return
+    if (this.editState.root === root && this.editState.observer) return
+
+    this.editState.observer?.disconnect()
+    const observer = new MutationObserver((mutations) => {
+      if (!this.mutationsContainElement(mutations, [
+        EDIT_LOGO_SELECTOR,
+        EDIT_PREVIEW_CHAT_ROOT_SELECTOR,
+        EDIT_PREVIEW_LOGO_SELECTOR,
+        CHAT_RELEVANT_SELECTOR,
+      ].join(','))) return
+      this.scheduleEditFlush()
+    })
+    observer.observe(root, { childList: true, subtree: true })
+    this.editState = { observer, root }
+  }
+
+  private installListObserver(): void {
+    const root = findFirstElement(LIST_ROOT_SELECTORS)
+    if (!root) return
+    if (this.listState.root === root && this.listState.observer) return
+
+    this.listState.observer?.disconnect()
+    const observer = new MutationObserver((mutations) => {
+      const rows = this.collectListRows(mutations)
+      if (rows.length === 0) return
+      rows.forEach((row) => this.scheduledListRows.add(row))
+      this.scheduleListFlush()
+    })
+    observer.observe(root, { childList: true, subtree: true })
+    this.listState = { observer, root }
+  }
+
+  private collectChatScopes(mutations: MutationRecord[]): Element[] {
+    const scopes: Element[] = []
+
+    for (const mutation of mutations) {
+      mutation.addedNodes.forEach((node) => {
+        if (!(node instanceof Element)) return
+        if (node.matches(CHAT_RELEVANT_SELECTOR)) {
+          scopes.push(node)
+        }
+        node.querySelectorAll(CHAT_RELEVANT_SELECTOR).forEach((element) => {
+          scopes.push(element)
+        })
+      })
+    }
+
+    return scopes
+  }
+
+  private mutationsContainElement(
+    mutations: MutationRecord[],
+    selector: string,
+  ): boolean {
+    return mutations.some((mutation) => Array.from(mutation.addedNodes).some((node) => {
+      if (!(node instanceof Element)) return false
+      return node.matches(selector) || Boolean(node.querySelector(selector))
+    }))
+  }
+
+  private collectListRows(mutations: MutationRecord[]): Element[] {
+    const rows: Element[] = []
+
+    for (const mutation of mutations) {
+      mutation.addedNodes.forEach((node) => {
+        if (!(node instanceof Element)) return
+        if (node.matches(LIST_ROW_SELECTOR)) {
+          rows.push(node)
+        }
+        node.querySelectorAll(LIST_ROW_SELECTOR).forEach((row) => {
+          rows.push(row)
+        })
+      })
+    }
+
+    return rows
+  }
+
+  private scheduleChatFlush(): void {
+    if (this.chatFrameId !== null) return
+    this.chatFrameId = requestAnimationFrame(() => {
+      this.chatFrameId = null
+      const scopes = [...this.scheduledChatScopes]
+      this.scheduledChatScopes.clear()
+      scopes.forEach((scope) => this.ensureChatAvatars(scope))
+    })
+  }
+
+  private scheduleChatRootRetryIfNeeded(): void {
+    if (
+      this.currentPage.kind !== 'chat'
+      || this.chatState.root
+      || this.chatRootRetryTimer !== null
+      || this.chatRootRetryAttempts >= CHAT_ROOT_RETRY_LIMIT
+    ) {
+      return
+    }
+
+    this.chatRootRetryTimer = window.setTimeout(() => {
+      this.chatRootRetryTimer = null
+      if (this.currentPage.kind !== 'chat') return
+
+      this.chatRootRetryAttempts += 1
+      this.installChatObserver()
+      if (this.chatState.root) {
+        this.ensureChatAvatars()
+        return
+      }
+      this.scheduleChatRootRetryIfNeeded()
+    }, CHAT_ROOT_RETRY_DELAY_MS)
+  }
+
+  private resetChatRouteSettleRetry(): void {
+    if (this.chatRouteSettleTimer !== null) {
+      window.clearTimeout(this.chatRouteSettleTimer)
+      this.chatRouteSettleTimer = null
+    }
+    this.chatRouteSettleAttempts = 0
+  }
+
+  private scheduleChatRouteSettleRetry(): void {
+    if (
+      this.currentPage.kind !== 'chat'
+      || this.chatRouteSettleTimer !== null
+      || this.chatRouteSettleAttempts >= CHAT_ROUTE_SETTLE_RETRY_LIMIT
+    ) {
+      return
+    }
+
+    this.chatRouteSettleTimer = window.setTimeout(() => {
+      this.chatRouteSettleTimer = null
+      if (this.currentPage.kind !== 'chat') return
+
+      const previousRoot = this.chatState.root
+      this.chatRouteSettleAttempts += 1
+      this.installChatObserver()
+      this.ensureChatAvatars()
+      this.ensureHeaderAvatar()
+
+      if (previousRoot !== this.chatState.root) {
+        logGemAvatar('chat observer root refreshed after route settle', {
+          previousRoot: describeElementForLog(previousRoot),
+          nextRoot: describeElementForLog(this.chatState.root),
+          attempt: this.chatRouteSettleAttempts,
+        })
+      }
+
+      this.scheduleChatRouteSettleRetry()
+    }, CHAT_ROUTE_SETTLE_RETRY_DELAY_MS)
+  }
+
+  private scheduleHeaderFlush(): void {
+    if (this.headerFrameId !== null) return
+    this.headerFrameId = requestAnimationFrame(() => {
+      this.headerFrameId = null
+      this.ensureHeaderAvatar()
+    })
+  }
+
+  private scheduleEditFlush(): void {
+    if (this.editFrameId !== null) return
+    this.editFrameId = requestAnimationFrame(() => {
+      this.editFrameId = null
+      this.ensureEditAvatar()
+    })
+  }
+
+  private scheduleListFlush(): void {
+    if (this.listFrameId !== null) return
+    this.listFrameId = requestAnimationFrame(() => {
+      this.listFrameId = null
+      const rows = [...this.scheduledListRows]
+      this.scheduledListRows.clear()
+      void this.ensureListAvatars(rows)
+    })
+  }
+
+  private ensureChatAvatars(scope: ParentNode | Element | null = this.chatState.root): void {
+    if (!scope || this.currentPage.kind !== 'chat' || !this.activeGemAvatarUrl) {
+      return
+    }
+
+    const gemId = this.currentPage.gemId
+    const userAvatarUrl = getImageSource(
+      document.querySelector<HTMLImageElement>(USER_AVATAR_SELECTOR),
+    )
+
+    this.ensureMatchingTargets(scope, USER_MESSAGE_TARGET_SELECTOR, (target) => {
+      if (userAvatarUrl) {
+        ensureMessageAvatar(target, 'user', userAvatarUrl)
+      }
+    })
+    this.ensureMatchingTargets(scope, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
+      ensureMessageAvatar(target, 'model', this.activeGemAvatarUrl!, 'normal', {
+        editGemId: gemId,
+      })
+    })
+  }
+
+  private ensureHeaderAvatar(): void {
+    if (this.currentPage.kind !== 'chat' || !this.activeGemAvatarUrl) {
+      return
+    }
+
+    const root = this.headerState.root ?? document
+    root.querySelectorAll(HEADER_LOGO_SELECTOR).forEach((logo) => {
+      ensureLogoAvatar(logo, this.activeGemAvatarUrl!, 'gpk-gem-avatar-header', {
+        editGemId: this.currentPage.kind === 'chat'
+          ? this.currentPage.gemId
+          : undefined,
+      })
+    })
+  }
+
+  private ensureEditAvatar(): void {
+    if (!isCreateOrEditPage(this.currentPage)) return
+
+    const previewUrl = getCurrentEditAvatarUrl(
+      this.currentPage,
+      this.pendingPreviewUrl,
+      this.activeGemAvatarUrl,
+    )
+
+    document.querySelectorAll(EDIT_LOGO_SELECTOR).forEach((logo) => {
+      this.ensureEditPreview(logo, previewUrl)
+    })
+    if (!previewUrl) {
+      this.removeEditPreviewAvatars()
+      return
+    }
+
+    this.ensureEditPreviewLogos(previewUrl)
+    this.ensureEditPreviewChatAvatars(previewUrl)
+  }
+
+  private ensureEditPreviewLogos(previewUrl: string | null): void {
+    if (!previewUrl) return
+
+    document.querySelectorAll(EDIT_PREVIEW_LOGO_SELECTOR).forEach((logo) => {
+      ensureLogoAvatar(logo, previewUrl, 'gpk-gem-avatar-edit-preview-logo')
+    })
+  }
+
+  private ensureEditPreviewChatAvatars(previewUrl: string | null): void {
+    if (!previewUrl) return
+
+    const userAvatarUrl = getImageSource(
+      document.querySelector<HTMLImageElement>(USER_AVATAR_SELECTOR),
+    )
+    document.querySelectorAll(EDIT_PREVIEW_CHAT_ROOT_SELECTOR).forEach((root) => {
+      if (root instanceof HTMLElement) {
+        root.classList.add(EDIT_PREVIEW_SCROLLER_CLASS)
+      }
+      this.ensureMatchingTargets(root, USER_MESSAGE_TARGET_SELECTOR, (target) => {
+        if (userAvatarUrl) {
+          ensureMessageAvatar(target, 'user', userAvatarUrl, 'compact')
+        }
+      })
+      this.ensureMatchingTargets(root, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
+        ensureMessageAvatar(target, 'model', previewUrl, 'compact')
+      })
+    })
+  }
+
+  private removeEditPreviewAvatars(): void {
+    document.querySelectorAll(EDIT_PREVIEW_LOGO_SELECTOR).forEach((logo) => {
+      const avatar = findDirectInjectedAvatar(logo, LOGO_AVATAR_CLASS)
+      if (avatar?.classList.contains('gpk-gem-avatar-edit-preview-logo')) {
+        avatar.remove()
+      }
+    })
+    document.querySelectorAll(EDIT_PREVIEW_CHAT_ROOT_SELECTOR).forEach((root) => {
+      if (root instanceof HTMLElement) {
+        root.classList.remove(EDIT_PREVIEW_SCROLLER_CLASS)
+      }
+      this.ensureMatchingTargets(root, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
+        removeDirectInjectedAvatar(target, 'gpk-gem-avatar-message-model')
+      })
+    })
+  }
+
+  private async ensureListAvatars(
+    rows: Iterable<Element> | null = null,
+  ): Promise<void> {
+    if (this.currentPage.kind !== 'list') return
+
+    const targets = rows
+      ? [...rows]
+      : [...document.querySelectorAll(LIST_ROW_SELECTOR)]
+
+    await Promise.all(targets.map((row) => this.ensureListRowAvatar(row)))
+  }
+
+  private async ensureListRowAvatar(row: Element): Promise<void> {
+    if (this.listCheckedRows.has(row)) return
+
+    const gemId = this.getGemIdFromListRow(row)
+    const logo = row.querySelector(LIST_ROW_LOGO_SELECTOR)
+    if (!gemId || !logo) return
+
+    this.listCheckedRows.add(row)
+    const avatarUrl = await this.resolveListAvatarUrl(gemId)
+    if (!avatarUrl || this.currentPage.kind !== 'list') return
+
+    ensureLogoAvatar(logo, avatarUrl, 'gpk-gem-avatar-list')
+  }
+
+  private getGemIdFromListRow(row: Element): string | null {
+    const link = row.querySelector<HTMLAnchorElement>(LIST_ROW_LINK_SELECTOR)
+    const href = link?.getAttribute('href') || link?.href
+    if (!href) return null
+
+    try {
+      const url = new URL(href, window.location.origin)
+      const match = url.pathname.match(/^\/gem\/([^/]+)\/?$/)
+      return match?.[1] ? decodeURIComponent(match[1]) : null
+    } catch {
+      return null
+    }
+  }
+
+  private async resolveListAvatarUrl(gemId: string): Promise<string | null> {
+    const existing = this.listAvatarUrls.get(gemId)
+    if (existing) return existing
+
+    const avatar = await gemAvatarRepository.getByGemId(gemId)
+    if (!avatar) return null
+
+    const objectUrl = URL.createObjectURL(avatar.blob)
+    this.listAvatarUrls.set(gemId, objectUrl)
+    return objectUrl
+  }
+
+  private ensureMatchingTargets(
+    scope: ParentNode | Element,
+    selector: string,
+    callback: (element: Element) => void,
+  ): void {
+    if (scope instanceof Element && scope.matches(selector)) {
+      callback(scope)
+    }
+    scope.querySelectorAll(selector).forEach(callback)
+  }
+
+  private ensureEditPreview(logo: Element, previewUrl: string | null): void {
+    if (!(logo instanceof HTMLElement)) return
+
+    let preview = findDirectInjectedAvatar(logo, 'gpk-gem-avatar-preview')
+    if (!preview) {
+      preview = document.createElement('gem-avatar-preview')
+      preview.className = 'gpk-gem-avatar-preview'
+      preview.setAttribute(INJECTED_ATTR, 'true')
+
+      const avatar = document.createElement('gem-avatar')
+      avatar.className = 'gpk-gem-avatar gpk-gem-avatar-edit'
+      avatar.setAttribute('aria-hidden', 'true')
+
+      const uploader = document.createElement('gem-avatar-uploader')
+      uploader.className = 'gpk-gem-avatar-uploader'
+      uploader.setAttribute('role', 'button')
+      uploader.setAttribute('tabindex', '0')
+      uploader.setAttribute('aria-label', 'Upload Gem avatar')
+      uploader.append(createEditIconSvg())
+
+      const deleteButton = createDeleteButton()
+
+      const input = document.createElement('input')
+      input.className = 'gpk-gem-avatar-file-input'
+      input.type = 'file'
+      input.accept = 'image/png,image/jpeg,image/webp'
+      input.addEventListener('change', () => {
+        const file = input.files?.[0]
+        input.value = ''
+        if (file) {
+          void this.handleAvatarFile(file)
+        }
+      })
+
+      const openFilePicker = (event: Event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        input.click()
+      }
+      uploader.addEventListener('click', openFilePicker)
+      uploader.addEventListener('keydown', (event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return
+        openFilePicker(event)
+      })
+      deleteButton.addEventListener('click', (event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        void this.handleDeleteAvatar()
+      })
+
+      preview.append(avatar, uploader, deleteButton, input)
+      logo.classList.add('gpk-gem-avatar-logo-anchor')
+      logo.append(preview)
+    }
+
+    const avatar = preview.querySelector<HTMLElement>('gem-avatar')
+    if (avatar) {
+      setAvatarImage(avatar, previewUrl)
+    }
+
+    const deleteButton = preview.querySelector<HTMLButtonElement>('.gpk-gem-avatar-delete')
+    if (deleteButton) {
+      deleteButton.hidden = this.currentPage.kind !== 'edit' || !previewUrl
+    }
+  }
+
+  private async handleAvatarFile(file: File): Promise<void> {
+    try {
+      const prepared = await gemAvatarRepository.prepare(file)
+
+      if (this.currentPage.kind === 'edit') {
+        await gemAvatarRepository.savePrepared(this.currentPage.gemId, prepared)
+        this.activeGemAvatarUrl = await gemAvatarRepository.resolveObjectUrl(this.currentPage.gemId)
+        this.clearPendingAvatar()
+      } else if (this.currentPage.kind === 'create') {
+        this.setPendingAvatar(prepared)
+      }
+
+      this.ensureEditAvatar()
+    } catch (error) {
+      console.warn('[GemAvatar] Failed to upload Gem avatar:', error)
+      window.alert('Choose a PNG, JPEG, or WebP image up to 3 MB.')
+    }
+  }
+
+  private async handleDeleteAvatar(): Promise<void> {
+    if (this.currentPage.kind !== 'edit' || !this.activeGemAvatarUrl) return
+
+    try {
+      await gemAvatarRepository.deleteByGemId(this.currentPage.gemId)
+      this.activeGemAvatarUrl = null
+      this.clearPendingAvatar()
+      this.ensureEditAvatar()
+    } catch (error) {
+      console.warn('[GemAvatar] Failed to delete Gem avatar:', error)
+      window.alert('Could not delete this Gem avatar. Try again.')
+    }
+  }
+
+  private setPendingAvatar(prepared: PreparedGemAvatarAsset): void {
+    this.clearPendingAvatar()
+    this.pendingAvatar = prepared
+    this.pendingPreviewUrl = URL.createObjectURL(prepared.blob)
+  }
+
+  private clearPendingAvatar(): void {
+    if (this.pendingPreviewUrl) {
+      URL.revokeObjectURL(this.pendingPreviewUrl)
+    }
+    this.pendingAvatar = null
+    this.pendingPreviewUrl = null
+  }
+
+  private clearActiveGemAvatar(): void {
+    gemAvatarRepository.revokeActiveObjectUrl()
+    this.activeGemAvatarUrl = null
+  }
+
+  private disconnectAllObservers(): void {
+    this.chatState.observer?.disconnect()
+    this.headerState.observer?.disconnect()
+    this.editState.observer?.disconnect()
+    this.listState.observer?.disconnect()
+    this.chatState = { observer: null, root: null }
+    this.headerState = { observer: null, root: null }
+    this.editState = { observer: null, root: null }
+    this.listState = { observer: null, root: null }
+  }
+
+  private cancelScheduledWork(): void {
+    if (this.chatFrameId !== null) {
+      cancelAnimationFrame(this.chatFrameId)
+      this.chatFrameId = null
+    }
+    if (this.headerFrameId !== null) {
+      cancelAnimationFrame(this.headerFrameId)
+      this.headerFrameId = null
+    }
+    if (this.editFrameId !== null) {
+      cancelAnimationFrame(this.editFrameId)
+      this.editFrameId = null
+    }
+    if (this.listFrameId !== null) {
+      cancelAnimationFrame(this.listFrameId)
+      this.listFrameId = null
+    }
+    if (this.chatRootRetryTimer !== null) {
+      window.clearTimeout(this.chatRootRetryTimer)
+      this.chatRootRetryTimer = null
+    }
+    if (this.chatRouteSettleTimer !== null) {
+      window.clearTimeout(this.chatRouteSettleTimer)
+      this.chatRouteSettleTimer = null
+    }
+    this.chatRootRetryAttempts = 0
+    this.chatRouteSettleAttempts = 0
+    this.scheduledChatScopes.clear()
+    this.scheduledListRows.clear()
+  }
+
+  private clearListAvatarUrls(): void {
+    this.listAvatarUrls.forEach((url) => {
+      URL.revokeObjectURL(url)
+    })
+    this.listAvatarUrls.clear()
+    this.listCheckedRows = new WeakSet<Element>()
+  }
+}
+
+export const gemAvatarModule = new GemAvatarModule()
+export { parseGemAvatarPage }

--- a/src/entrypoints/content/gem-avatar/index.ts
+++ b/src/entrypoints/content/gem-avatar/index.ts
@@ -122,6 +122,7 @@ class GemAvatarModule {
     this.unsubscribeUrlChange = null
     this.disconnectAllObservers()
     this.cancelScheduledWork()
+    removeInjectedAvatars()
     this.clearPendingAvatar()
     this.clearActiveGemAvatar()
     this.clearListAvatarUrls()

--- a/src/entrypoints/content/gem-avatar/index.ts
+++ b/src/entrypoints/content/gem-avatar/index.ts
@@ -5,94 +5,54 @@ import type {
 } from '@/domain/gem-avatar/types'
 import { eventBus } from '@/utils/eventbus'
 
+import {
+  createDeleteButton,
+  createUploaderElement,
+  ensureLogoAvatar,
+  ensureMatchingTargets,
+  ensureMessageAvatar,
+  findDirectInjectedAvatar,
+  findFirstElement,
+  getImageSource,
+  removeDirectInjectedAvatar,
+  removeInjectedAvatars,
+  setAvatarImage,
+} from './dom'
+import {
+  describeElementForLog,
+  describePageForLog,
+  logGemAvatarEvent,
+} from './logger'
 import { getGemAvatarRouteKey, parseGemAvatarPage } from './route'
-import './style.css'
-
-const INJECTED_ATTR = 'data-gpk-gem-avatar-injected'
-const CHAT_ROOT_SELECTORS = [
-  'chat-window #chat-history infinite-scroller[data-test-id="chat-history-container"]',
-  '#chat-history infinite-scroller',
-  'chat-window',
-] as const
-const HEADER_ROOT_SELECTORS = ['chat-window', 'body'] as const
-const EDIT_ROOT_SELECTORS = ['bots-creation-window', 'body'] as const
-const LIST_ROOT_SELECTORS = ['div.bots-section-container', 'body'] as const
-const EDIT_LOGO_SELECTOR = 'bots-creation-window div.title-container > bot-logo'
-const EDIT_PREVIEW_CHAT_ROOT_SELECTOR = 'bots-creation-window infinite-scroller'
-const EDIT_PREVIEW_LOGO_SELECTOR = `${EDIT_PREVIEW_CHAT_ROOT_SELECTOR} bot-logo`
-const HEADER_LOGO_SELECTOR = 'bot-logo'
-const LIST_ROW_SELECTOR = 'div.bots-section-container bot-list-row'
-const LIST_ROW_LINK_SELECTOR = 'a.bot-row[href^="/gem/"], a.bot-row[href*="/gem/"]'
-const LIST_ROW_LOGO_SELECTOR = 'bot-logo'
-const USER_AVATAR_SELECTOR = 'sidenav-mavatar-footer > div.mavatar-footer-row > a > div.mavatar-container > img.mavatar-image'
-const USER_MESSAGE_TARGET_SELECTOR = 'user-query-content > div.user-query-container'
-const MODEL_MESSAGE_TARGET_SELECTOR = 'response-container > div.response-container'
-const LOGO_AVATAR_CLASS = 'gpk-gem-avatar-logo'
-const LOGO_AVATAR_CLICKABLE_CLASS = 'gpk-gem-avatar-logo-clickable'
-const MESSAGE_AVATAR_CLICKABLE_CLASS = 'gpk-gem-avatar-message-clickable'
-const RECENT_CHAT_LOGO_AVATAR_CLASS = 'gpk-gem-avatar-recent-chat-logo'
-const EDIT_PREVIEW_SCROLLER_CLASS = 'gpk-gem-avatar-edit-preview-scroller'
-const CHAT_RELEVANT_SELECTOR = [
-  '.conversation-container',
-  'user-query',
-  'model-response',
-  USER_MESSAGE_TARGET_SELECTOR,
+import {
+  CHAT_RELEVANT_SELECTOR,
+  CHAT_ROOT_RETRY_DELAY_MS,
+  CHAT_ROOT_RETRY_LIMIT,
+  CHAT_ROOT_SELECTORS,
+  CHAT_ROUTE_SETTLE_RETRY_DELAY_MS,
+  CHAT_ROUTE_SETTLE_RETRY_LIMIT,
+  EDIT_LOGO_SELECTOR,
+  EDIT_PREVIEW_CHAT_ROOT_SELECTOR,
+  EDIT_PREVIEW_LOGO_SELECTOR,
+  EDIT_PREVIEW_SCROLLER_CLASS,
+  EDIT_ROOT_SELECTORS,
+  HEADER_LOGO_SELECTOR,
+  HEADER_ROOT_SELECTORS,
+  INJECTED_ATTR,
+  LIST_ROOT_SELECTORS,
+  LIST_ROW_LINK_SELECTOR,
+  LIST_ROW_LOGO_SELECTOR,
+  LIST_ROW_SELECTOR,
+  LOGO_AVATAR_CLASS,
   MODEL_MESSAGE_TARGET_SELECTOR,
-].join(',')
-const CHAT_ROOT_RETRY_LIMIT = 20
-const CHAT_ROOT_RETRY_DELAY_MS = 250
-const CHAT_ROUTE_SETTLE_RETRY_LIMIT = 12
-const CHAT_ROUTE_SETTLE_RETRY_DELAY_MS = 250
+  USER_AVATAR_SELECTOR,
+  USER_MESSAGE_TARGET_SELECTOR,
+} from './selectors'
+import './style.css'
 
 interface ObserverState {
   observer: MutationObserver | null
   root: Element | null
-}
-
-interface LogoAvatarOptions {
-  editGemId?: string
-}
-
-interface MessageAvatarOptions {
-  editGemId?: string
-}
-
-function findFirstElement(selectors: readonly string[]): Element | null {
-  for (const selector of selectors) {
-    const element = document.querySelector(selector)
-    if (element) return element
-  }
-  return null
-}
-
-function describePageForLog(page: GemAvatarPage): string {
-  if (page.kind === 'chat') {
-    return page.chatId
-      ? `chat:${page.gemId}/${page.chatId}`
-      : `chat:${page.gemId}`
-  }
-  if (page.kind === 'edit') {
-    return `edit:${page.gemId}`
-  }
-  return page.kind
-}
-
-function describeElementForLog(element: Element | null): string | null {
-  if (!element) return null
-
-  const tag = element.tagName.toLowerCase()
-  const id = element.id ? `#${element.id}` : ''
-  const testId = element.getAttribute('data-test-id')
-  const testIdText = testId ? `[data-test-id="${testId}"]` : ''
-  return `${tag}${id}${testIdText}`
-}
-
-function logGemAvatar(message: string, details?: Record<string, unknown>): void {
-  if (details) {
-    console.log(`[GemAvatar] ${message}`, details)
-    return
-  }
-  console.log(`[GemAvatar] ${message}`)
 }
 
 function pageUsesSameContext(a: GemAvatarPage, b: GemAvatarPage): boolean {
@@ -101,193 +61,6 @@ function pageUsesSameContext(a: GemAvatarPage, b: GemAvatarPage): boolean {
 
 function isCreateOrEditPage(page: GemAvatarPage): boolean {
   return page.kind === 'create' || page.kind === 'edit'
-}
-
-function getImageSource(image: HTMLImageElement | null): string | null {
-  const source = image?.currentSrc || image?.src || image?.getAttribute('src')
-  return source?.trim() || null
-}
-
-function createEditIconSvg(): SVGSVGElement {
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  svg.setAttribute('viewBox', '0 0 24 24')
-  svg.setAttribute('aria-hidden', 'true')
-  svg.setAttribute('focusable', 'false')
-
-  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-  path.setAttribute('fill', 'currentColor')
-  path.setAttribute('d', 'M4 17.46V20h2.54L17.6 8.94l-2.54-2.54L4 17.46Zm15.56-10.48c.59-.59.59-1.54 0-2.12L18.14 3.44a1.5 1.5 0 0 0-2.12 0l-1.1 1.1 2.54 2.54 1.1-1.1Z')
-  svg.append(path)
-  return svg
-}
-
-function createCloseIconSvg(): SVGSVGElement {
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  svg.setAttribute('viewBox', '0 0 24 24')
-  svg.setAttribute('aria-hidden', 'true')
-  svg.setAttribute('focusable', 'false')
-
-  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-  path.setAttribute('fill', 'none')
-  path.setAttribute('stroke', 'currentColor')
-  path.setAttribute('stroke-linecap', 'round')
-  path.setAttribute('stroke-linejoin', 'round')
-  path.setAttribute('stroke-width', '3')
-  path.setAttribute('d', 'M18 6 6 18M6 6l12 12')
-  svg.append(path)
-  return svg
-}
-
-function createDeleteButton(): HTMLButtonElement {
-  const button = document.createElement('button')
-  button.type = 'button'
-  button.className = 'gpk-gem-avatar-delete'
-  button.setAttribute('aria-label', 'Delete Gem avatar')
-  button.append(createCloseIconSvg())
-  return button
-}
-
-function getGemEditUrl(gemId: string): string {
-  return new URL(`/gems/edit/${encodeURIComponent(gemId)}`, window.location.origin).href
-}
-
-function setAvatarImage(avatar: HTMLElement, src: string | null): void {
-  let image = avatar.querySelector('img')
-  if (!src) {
-    image?.remove()
-    avatar.removeAttribute('data-gpk-gem-avatar-src')
-    return
-  }
-
-  if (!image) {
-    image = document.createElement('img')
-    image.alt = ''
-    image.decoding = 'async'
-    image.loading = 'lazy'
-    avatar.append(image)
-  }
-
-  if (avatar.getAttribute('data-gpk-gem-avatar-src') !== src) {
-    image.src = src
-    avatar.setAttribute('data-gpk-gem-avatar-src', src)
-  }
-}
-
-function removeDirectInjectedAvatar(target: Element, className: string): void {
-  findDirectInjectedAvatar(target, className)?.remove()
-}
-
-function configureAvatarEditPageInteraction(
-  avatar: HTMLElement,
-  editGemId: string | undefined,
-  clickableClassName: string,
-): void {
-  if (!editGemId) {
-    avatar.classList.remove(clickableClassName)
-    avatar.removeAttribute('role')
-    avatar.removeAttribute('tabindex')
-    avatar.removeAttribute('title')
-    avatar.removeAttribute('aria-label')
-    avatar.setAttribute('aria-hidden', 'true')
-    avatar.onclick = null
-    avatar.onkeydown = null
-    return
-  }
-
-  const openEditPage = (event: Event) => {
-    event.preventDefault()
-    event.stopPropagation()
-    window.open(getGemEditUrl(editGemId), '_blank', 'noopener,noreferrer')
-  }
-
-  avatar.classList.add(clickableClassName)
-  avatar.removeAttribute('aria-hidden')
-  avatar.setAttribute('role', 'link')
-  avatar.setAttribute('tabindex', '0')
-  avatar.setAttribute('title', 'Open Gem editor')
-  avatar.setAttribute('aria-label', 'Open Gem editor')
-  avatar.onclick = openEditPage
-  avatar.onkeydown = (event) => {
-    if (event.key !== 'Enter' && event.key !== ' ') return
-    openEditPage(event)
-  }
-}
-
-function findDirectInjectedAvatar(
-  target: Element,
-  className: string,
-): HTMLElement | null {
-  return Array.from(target.children).find((child) => (
-    child instanceof HTMLElement && child.classList.contains(className)
-  )) as HTMLElement | null
-}
-
-function ensureMessageAvatar(
-  target: Element,
-  variant: 'user' | 'model',
-  src: string,
-  size: 'normal' | 'compact' = 'normal',
-  options: MessageAvatarOptions = {},
-): void {
-  if (!(target instanceof HTMLElement)) return
-
-  const className = variant === 'user'
-    ? 'gpk-gem-avatar-message-user'
-    : 'gpk-gem-avatar-message-model'
-  const existing = findDirectInjectedAvatar(target, className)
-  const avatar = existing ?? document.createElement('gem-avatar')
-
-  avatar.className = [
-    'gpk-gem-avatar',
-    'gpk-gem-avatar-message',
-    className,
-    size === 'compact' ? 'gpk-gem-avatar-message-compact' : '',
-  ].join(' ')
-  avatar.setAttribute(INJECTED_ATTR, 'true')
-  avatar.setAttribute('aria-hidden', 'true')
-  setAvatarImage(avatar, src)
-  configureAvatarEditPageInteraction(
-    avatar,
-    options.editGemId,
-    MESSAGE_AVATAR_CLICKABLE_CLASS,
-  )
-
-  target.classList.add('gpk-gem-avatar-anchor')
-  if (!existing) {
-    target.append(avatar)
-  }
-}
-
-function ensureLogoAvatar(
-  target: Element,
-  src: string,
-  className: string,
-  options: LogoAvatarOptions = {},
-): void {
-  if (!(target instanceof HTMLElement)) return
-
-  const existing = findDirectInjectedAvatar(target, LOGO_AVATAR_CLASS)
-  const avatar = existing ?? document.createElement('gem-avatar')
-  const classNames = ['gpk-gem-avatar', LOGO_AVATAR_CLASS, className]
-
-  if (target.closest('recent-chat-list-item')) {
-    classNames.push(RECENT_CHAT_LOGO_AVATAR_CLASS)
-  }
-
-  avatar.className = classNames.join(' ')
-  avatar.setAttribute(INJECTED_ATTR, 'true')
-  avatar.setAttribute('aria-hidden', 'true')
-  setAvatarImage(avatar, src)
-  configureAvatarEditPageInteraction(
-    avatar,
-    options.editGemId,
-    LOGO_AVATAR_CLICKABLE_CLASS,
-  )
-
-  target.classList.add('gpk-gem-avatar-logo-anchor')
-  if (!existing) {
-    target.append(avatar)
-  }
 }
 
 function getCurrentEditAvatarUrl(
@@ -302,12 +75,6 @@ function getCurrentEditAvatarUrl(
     return pendingPreviewUrl ?? activeGemAvatarUrl
   }
   return null
-}
-
-function removeInjectedAvatars(root: ParentNode = document): void {
-  root.querySelectorAll(`[${INJECTED_ATTR}="true"]`).forEach((node) => {
-    node.remove()
-  })
 }
 
 class GemAvatarModule {
@@ -339,7 +106,7 @@ class GemAvatarModule {
 
     this.isStarted = true
     this.unsubscribeUrlChange = eventBus.on('urlchange', (event) => {
-      logGemAvatar('urlchange received', {
+      logGemAvatarEvent('urlchange-received', {
         eventUrl: event.url,
         href: window.location.href,
       })
@@ -369,7 +136,7 @@ class GemAvatarModule {
     const sameContext = pageUsesSameContext(this.currentPage, nextPage)
     const previousPage = this.currentPage
 
-    logGemAvatar('sync route', {
+    logGemAvatarEvent('route-sync', {
       previousPage: describePageForLog(previousPage),
       nextPage: describePageForLog(nextPage),
       sameContext,
@@ -398,7 +165,7 @@ class GemAvatarModule {
 
     if (nextPage.kind === 'chat') {
       this.activeGemAvatarUrl = await gemAvatarRepository.resolveObjectUrl(nextPage.gemId)
-      logGemAvatar('chat avatar resolved', {
+      logGemAvatarEvent('chat-avatar-resolved', {
         page: describePageForLog(nextPage),
         hasAvatar: Boolean(this.activeGemAvatarUrl),
       })
@@ -440,7 +207,7 @@ class GemAvatarModule {
   private installChatObserver(): void {
     const root = findFirstElement(CHAT_ROOT_SELECTORS)
     if (!root) {
-      logGemAvatar('chat observer root missing')
+      logGemAvatarEvent('chat-observer-root-missing')
       return
     }
     if (this.chatState.root === root && this.chatState.observer) {
@@ -457,7 +224,7 @@ class GemAvatarModule {
     observer.observe(root, { childList: true, subtree: true })
     this.chatState = { observer, root }
     this.chatRootRetryAttempts = 0
-    logGemAvatar('chat observer installed', {
+    logGemAvatarEvent('chat-observer-installed', {
       root: describeElementForLog(root),
     })
   }
@@ -619,7 +386,7 @@ class GemAvatarModule {
       this.ensureHeaderAvatar()
 
       if (previousRoot !== this.chatState.root) {
-        logGemAvatar('chat observer root refreshed after route settle', {
+        logGemAvatarEvent('chat-observer-root-refreshed-after-route-settle', {
           previousRoot: describeElementForLog(previousRoot),
           nextRoot: describeElementForLog(this.chatState.root),
           attempt: this.chatRouteSettleAttempts,
@@ -666,12 +433,12 @@ class GemAvatarModule {
       document.querySelector<HTMLImageElement>(USER_AVATAR_SELECTOR),
     )
 
-    this.ensureMatchingTargets(scope, USER_MESSAGE_TARGET_SELECTOR, (target) => {
+    ensureMatchingTargets(scope, USER_MESSAGE_TARGET_SELECTOR, (target) => {
       if (userAvatarUrl) {
         ensureMessageAvatar(target, 'user', userAvatarUrl)
       }
     })
-    this.ensureMatchingTargets(scope, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
+    ensureMatchingTargets(scope, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
       ensureMessageAvatar(target, 'model', this.activeGemAvatarUrl!, 'normal', {
         editGemId: gemId,
       })
@@ -732,12 +499,12 @@ class GemAvatarModule {
       if (root instanceof HTMLElement) {
         root.classList.add(EDIT_PREVIEW_SCROLLER_CLASS)
       }
-      this.ensureMatchingTargets(root, USER_MESSAGE_TARGET_SELECTOR, (target) => {
+      ensureMatchingTargets(root, USER_MESSAGE_TARGET_SELECTOR, (target) => {
         if (userAvatarUrl) {
           ensureMessageAvatar(target, 'user', userAvatarUrl, 'compact')
         }
       })
-      this.ensureMatchingTargets(root, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
+      ensureMatchingTargets(root, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
         ensureMessageAvatar(target, 'model', previewUrl, 'compact')
       })
     })
@@ -754,7 +521,7 @@ class GemAvatarModule {
       if (root instanceof HTMLElement) {
         root.classList.remove(EDIT_PREVIEW_SCROLLER_CLASS)
       }
-      this.ensureMatchingTargets(root, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
+      ensureMatchingTargets(root, MODEL_MESSAGE_TARGET_SELECTOR, (target) => {
         removeDirectInjectedAvatar(target, 'gpk-gem-avatar-message-model')
       })
     })
@@ -812,17 +579,6 @@ class GemAvatarModule {
     return objectUrl
   }
 
-  private ensureMatchingTargets(
-    scope: ParentNode | Element,
-    selector: string,
-    callback: (element: Element) => void,
-  ): void {
-    if (scope instanceof Element && scope.matches(selector)) {
-      callback(scope)
-    }
-    scope.querySelectorAll(selector).forEach(callback)
-  }
-
   private ensureEditPreview(logo: Element, previewUrl: string | null): void {
     if (!(logo instanceof HTMLElement)) return
 
@@ -836,13 +592,7 @@ class GemAvatarModule {
       avatar.className = 'gpk-gem-avatar gpk-gem-avatar-edit'
       avatar.setAttribute('aria-hidden', 'true')
 
-      const uploader = document.createElement('gem-avatar-uploader')
-      uploader.className = 'gpk-gem-avatar-uploader'
-      uploader.setAttribute('role', 'button')
-      uploader.setAttribute('tabindex', '0')
-      uploader.setAttribute('aria-label', 'Upload Gem avatar')
-      uploader.append(createEditIconSvg())
-
+      const uploader = createUploaderElement()
       const deleteButton = createDeleteButton()
 
       const input = document.createElement('input')

--- a/src/entrypoints/content/gem-avatar/logger.ts
+++ b/src/entrypoints/content/gem-avatar/logger.ts
@@ -1,0 +1,33 @@
+import type { GemAvatarPage } from '@/domain/gem-avatar/types'
+import { logDevEvent } from '@/utils/devLogger'
+
+const GEM_AVATAR_LOG_LABEL = '[GemAvatar]'
+
+export function describePageForLog(page: GemAvatarPage): string {
+  if (page.kind === 'chat') {
+    return page.chatId
+      ? `chat:${page.gemId}/${page.chatId}`
+      : `chat:${page.gemId}`
+  }
+  if (page.kind === 'edit') {
+    return `edit:${page.gemId}`
+  }
+  return page.kind
+}
+
+export function describeElementForLog(element: Element | null): string | null {
+  if (!element) return null
+
+  const tag = element.tagName.toLowerCase()
+  const id = element.id ? `#${element.id}` : ''
+  const testId = element.getAttribute('data-test-id')
+  const testIdText = testId ? `[data-test-id="${testId}"]` : ''
+  return `${tag}${id}${testIdText}`
+}
+
+export function logGemAvatarEvent(
+  event: string,
+  details: Record<string, unknown> = {},
+): void {
+  logDevEvent('info', GEM_AVATAR_LOG_LABEL, event, details)
+}

--- a/src/entrypoints/content/gem-avatar/route.test.ts
+++ b/src/entrypoints/content/gem-avatar/route.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { getGemAvatarRouteKey, parseGemAvatarPage } from './route'
+
+describe('parseGemAvatarPage', () => {
+  it('detects Gem create and edit pages', () => {
+    expect(parseGemAvatarPage('https://gemini.google.com/gems/create')).toEqual({
+      kind: 'create',
+    })
+    expect(parseGemAvatarPage('https://gemini.google.com/gems/view')).toEqual({
+      kind: 'list',
+    })
+    expect(parseGemAvatarPage('https://gemini.google.com/gems/edit/gem-1')).toEqual({
+      kind: 'edit',
+      gemId: 'gem-1',
+    })
+  })
+
+  it('detects Gem chat pages', () => {
+    expect(parseGemAvatarPage('https://gemini.google.com/gem/gem-1')).toEqual({
+      kind: 'chat',
+      gemId: 'gem-1',
+      chatId: undefined,
+    })
+    expect(parseGemAvatarPage('https://gemini.google.com/gem/gem-1/chat-1')).toEqual({
+      kind: 'chat',
+      gemId: 'gem-1',
+      chatId: 'chat-1',
+    })
+  })
+
+  it('returns other for non-Gem pages', () => {
+    expect(parseGemAvatarPage('https://gemini.google.com/app')).toEqual({
+      kind: 'other',
+    })
+  })
+
+  it('includes chatId in Gem chat route keys', () => {
+    expect(getGemAvatarRouteKey({
+      kind: 'chat',
+      gemId: 'gem-1',
+    })).toBe('chat:gem-1:')
+    expect(getGemAvatarRouteKey({
+      kind: 'chat',
+      gemId: 'gem-1',
+      chatId: 'chat-1',
+    })).toBe('chat:gem-1:chat-1')
+  })
+})

--- a/src/entrypoints/content/gem-avatar/route.ts
+++ b/src/entrypoints/content/gem-avatar/route.ts
@@ -1,0 +1,49 @@
+import type { GemAvatarPage } from '@/domain/gem-avatar/types'
+
+function decodePathSegment(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+export function parseGemAvatarPage(input: string | URL): GemAvatarPage {
+  const pathname = typeof input === 'string'
+    ? new URL(input, window.location.origin).pathname
+    : input.pathname
+
+  if (/^\/gems\/create\/?$/.test(pathname)) {
+    return { kind: 'create' }
+  }
+
+  if (/^\/gems\/view\/?$/.test(pathname)) {
+    return { kind: 'list' }
+  }
+
+  const editMatch = pathname.match(/^\/gems\/edit\/([^/]+)\/?$/)
+  if (editMatch) {
+    const gemId = decodePathSegment(editMatch[1])
+    return gemId ? { kind: 'edit', gemId } : { kind: 'other' }
+  }
+
+  const chatMatch = pathname.match(/^\/gem\/([^/]+)(?:\/([^/]+))?\/?$/)
+  if (chatMatch) {
+    const gemId = decodePathSegment(chatMatch[1])
+    const chatId = decodePathSegment(chatMatch[2])
+    return gemId ? { kind: 'chat', gemId, chatId } : { kind: 'other' }
+  }
+
+  return { kind: 'other' }
+}
+
+export function getGemAvatarRouteKey(page: GemAvatarPage): string {
+  if (page.kind === 'chat') {
+    return `${page.kind}:${page.gemId}:${page.chatId ?? ''}`
+  }
+  if (page.kind === 'edit') {
+    return `${page.kind}:${page.gemId}`
+  }
+  return page.kind
+}

--- a/src/entrypoints/content/gem-avatar/selectors.ts
+++ b/src/entrypoints/content/gem-avatar/selectors.ts
@@ -1,0 +1,40 @@
+export const INJECTED_ATTR = 'data-gpk-gem-avatar-injected'
+
+export const CHAT_ROOT_SELECTORS = [
+  'chat-window #chat-history infinite-scroller[data-test-id="chat-history-container"]',
+  '#chat-history infinite-scroller',
+  'chat-window',
+] as const
+export const HEADER_ROOT_SELECTORS = ['chat-window', 'body'] as const
+export const EDIT_ROOT_SELECTORS = ['bots-creation-window', 'body'] as const
+export const LIST_ROOT_SELECTORS = ['div.bots-section-container', 'body'] as const
+
+export const EDIT_LOGO_SELECTOR = 'bots-creation-window div.title-container > bot-logo'
+export const EDIT_PREVIEW_CHAT_ROOT_SELECTOR = 'bots-creation-window infinite-scroller'
+export const EDIT_PREVIEW_LOGO_SELECTOR = `${EDIT_PREVIEW_CHAT_ROOT_SELECTOR} bot-logo`
+export const HEADER_LOGO_SELECTOR = 'bot-logo'
+export const LIST_ROW_SELECTOR = 'div.bots-section-container bot-list-row'
+export const LIST_ROW_LINK_SELECTOR = 'a.bot-row[href^="/gem/"], a.bot-row[href*="/gem/"]'
+export const LIST_ROW_LOGO_SELECTOR = 'bot-logo'
+export const USER_AVATAR_SELECTOR = 'sidenav-mavatar-footer > div.mavatar-footer-row > a > div.mavatar-container > img.mavatar-image'
+export const USER_MESSAGE_TARGET_SELECTOR = 'user-query-content > div.user-query-container'
+export const MODEL_MESSAGE_TARGET_SELECTOR = 'response-container > div.response-container'
+
+export const LOGO_AVATAR_CLASS = 'gpk-gem-avatar-logo'
+export const LOGO_AVATAR_CLICKABLE_CLASS = 'gpk-gem-avatar-logo-clickable'
+export const MESSAGE_AVATAR_CLICKABLE_CLASS = 'gpk-gem-avatar-message-clickable'
+export const RECENT_CHAT_LOGO_AVATAR_CLASS = 'gpk-gem-avatar-recent-chat-logo'
+export const EDIT_PREVIEW_SCROLLER_CLASS = 'gpk-gem-avatar-edit-preview-scroller'
+
+export const CHAT_RELEVANT_SELECTOR = [
+  '.conversation-container',
+  'user-query',
+  'model-response',
+  USER_MESSAGE_TARGET_SELECTOR,
+  MODEL_MESSAGE_TARGET_SELECTOR,
+].join(',')
+
+export const CHAT_ROOT_RETRY_LIMIT = 20
+export const CHAT_ROOT_RETRY_DELAY_MS = 250
+export const CHAT_ROUTE_SETTLE_RETRY_LIMIT = 12
+export const CHAT_ROUTE_SETTLE_RETRY_DELAY_MS = 250

--- a/src/entrypoints/content/gem-avatar/settings.test.ts
+++ b/src/entrypoints/content/gem-avatar/settings.test.ts
@@ -66,4 +66,23 @@ describe('GemAvatarSettingsController', () => {
     expect(start).toHaveBeenCalledTimes(2)
     expect(stop).toHaveBeenCalledTimes(2)
   })
+
+  it('keeps Gem Avatar disabled when reading the setting fails', async () => {
+    const setting: GemAvatarBooleanSetting = {
+      getValue: vi.fn(async () => {
+        throw new Error('storage unavailable')
+      }),
+      watch: vi.fn(() => () => undefined),
+    }
+    const start = vi.fn()
+    const stop = vi.fn()
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const controller = createGemAvatarSettingsController({ setting, start, stop })
+
+    await controller.start()
+
+    expect(start).not.toHaveBeenCalled()
+    expect(stop).toHaveBeenCalledOnce()
+    warning.mockRestore()
+  })
 })

--- a/src/entrypoints/content/gem-avatar/settings.test.ts
+++ b/src/entrypoints/content/gem-avatar/settings.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createGemAvatarSettingsController,
+  type GemAvatarBooleanSetting,
+} from './settings'
+
+function createSetting(initialValue: boolean): {
+  setting: GemAvatarBooleanSetting
+  setValue: (value: boolean) => void
+} {
+  let listener: ((enabled: boolean) => void) | null = null
+
+  return {
+    setting: {
+      getValue: vi.fn(async () => initialValue),
+      watch: vi.fn((callback) => {
+        listener = callback
+        return () => {
+          listener = null
+        }
+      }),
+    },
+    setValue(value) {
+      listener?.(value)
+    },
+  }
+}
+
+describe('GemAvatarSettingsController', () => {
+  it('starts Gem Avatar when the persisted setting is enabled', async () => {
+    const { setting } = createSetting(true)
+    const start = vi.fn()
+    const stop = vi.fn()
+    const controller = createGemAvatarSettingsController({ setting, start, stop })
+
+    await controller.start()
+
+    expect(start).toHaveBeenCalledOnce()
+    expect(stop).not.toHaveBeenCalled()
+  })
+
+  it('stops Gem Avatar when the persisted setting is disabled', async () => {
+    const { setting } = createSetting(false)
+    const start = vi.fn()
+    const stop = vi.fn()
+    const controller = createGemAvatarSettingsController({ setting, start, stop })
+
+    await controller.start()
+
+    expect(start).not.toHaveBeenCalled()
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
+  it('applies setting changes immediately and unsubscribes during cleanup', async () => {
+    const { setting, setValue } = createSetting(true)
+    const start = vi.fn()
+    const stop = vi.fn()
+    const controller = createGemAvatarSettingsController({ setting, start, stop })
+
+    await controller.start()
+    setValue(false)
+    setValue(true)
+    controller.stop()
+    setValue(false)
+
+    expect(start).toHaveBeenCalledTimes(2)
+    expect(stop).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/entrypoints/content/gem-avatar/settings.ts
+++ b/src/entrypoints/content/gem-avatar/settings.ts
@@ -1,0 +1,64 @@
+export interface GemAvatarBooleanSetting {
+  getValue: () => Promise<boolean>
+  watch: (callback: (enabled: boolean) => void) => () => void
+}
+
+interface GemAvatarSettingsControllerOptions {
+  setting: GemAvatarBooleanSetting
+  start: () => void
+  stop: () => void
+}
+
+export interface GemAvatarSettingsController {
+  start: () => Promise<void>
+  stop: () => void
+}
+
+export function createGemAvatarSettingsController({
+  setting,
+  start,
+  stop,
+}: GemAvatarSettingsControllerOptions): GemAvatarSettingsController {
+  let isStarted = false
+  let unwatch: (() => void) | null = null
+
+  const applySetting = (enabled: boolean): void => {
+    if (enabled) {
+      start()
+      return
+    }
+
+    stop()
+  }
+
+  return {
+    async start() {
+      if (isStarted) {
+        return
+      }
+
+      isStarted = true
+
+      let enabled = true
+      try {
+        enabled = await setting.getValue()
+      } catch (error) {
+        console.warn('[GemAvatar] Failed to load setting; enabling by default', error)
+      }
+
+      if (!isStarted) {
+        return
+      }
+
+      applySetting(enabled)
+      unwatch = setting.watch(applySetting)
+    },
+
+    stop() {
+      isStarted = false
+      unwatch?.()
+      unwatch = null
+      stop()
+    },
+  }
+}

--- a/src/entrypoints/content/gem-avatar/settings.ts
+++ b/src/entrypoints/content/gem-avatar/settings.ts
@@ -39,11 +39,11 @@ export function createGemAvatarSettingsController({
 
       isStarted = true
 
-      let enabled = true
+      let enabled = false
       try {
         enabled = await setting.getValue()
       } catch (error) {
-        console.warn('[GemAvatar] Failed to load setting; enabling by default', error)
+        console.warn('[GemAvatar] Failed to load setting; disabling by default', error)
       }
 
       if (!isStarted) {

--- a/src/entrypoints/content/gem-avatar/style.css
+++ b/src/entrypoints/content/gem-avatar/style.css
@@ -1,0 +1,208 @@
+.gpk-gem-avatar-logo-anchor,
+.gpk-gem-avatar-anchor {
+  position: relative !important;
+}
+
+.gpk-gem-avatar-anchor {
+  overflow: visible !important;
+}
+
+.gpk-gem-avatar-logo-anchor {
+  isolation: isolate;
+}
+
+.gpk-gem-avatar,
+.gpk-gem-avatar-preview,
+.gpk-gem-avatar-uploader,
+.gpk-gem-avatar-delete {
+  box-sizing: border-box;
+}
+
+.gpk-gem-avatar {
+  display: block;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+
+.gpk-gem-avatar img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.gpk-gem-avatar-logo-anchor > :not(.gpk-gem-avatar-logo):not(.gpk-gem-avatar-preview) {
+  position: relative;
+  z-index: 0;
+}
+
+.gpk-gem-avatar-logo {
+  position: absolute !important;
+  top: 0;
+  left: 0;
+  z-index: 2147483646;
+  width: var(--bot-logo-size, 100%);
+  height: var(--bot-logo-size, 100%);
+  pointer-events: none;
+}
+
+.gpk-gem-avatar-logo-clickable {
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.gpk-gem-avatar-logo-clickable:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.gpk-gem-avatar-recent-chat-logo {
+  border-radius: calc(var(--bot-logo-size, 32px) / 3);
+}
+
+.gpk-gem-avatar-preview {
+  position: absolute;
+  inset: 0;
+  z-index: 2147483647;
+  display: grid;
+  place-items: center;
+  overflow: visible;
+  border-radius: 999px;
+}
+
+.gpk-gem-avatar-preview::before {
+  position: absolute;
+  inset: -8px;
+  z-index: 0;
+  content: '';
+  border-radius: 999px;
+}
+
+.gpk-gem-avatar-edit {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.gpk-gem-avatar-uploader {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  cursor: pointer;
+  background: rgba(32, 33, 36, 0.42);
+  border-radius: 999px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.gpk-gem-avatar-preview:hover .gpk-gem-avatar-uploader,
+.gpk-gem-avatar-uploader:focus-visible {
+  opacity: 1;
+}
+
+.gpk-gem-avatar-uploader svg {
+  width: 18px;
+  height: 18px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.32));
+}
+
+.gpk-gem-avatar-delete {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  display: grid;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  place-items: center;
+  color: #fff;
+  cursor: pointer;
+  background: rgba(32, 33, 36, 0.72);
+  border: 0;
+  border-radius: 999px;
+  opacity: 0;
+  transition:
+    background 120ms ease,
+    opacity 120ms ease;
+}
+
+.gpk-gem-avatar-delete svg {
+  width: 10px;
+  height: 10px;
+}
+
+.gpk-gem-avatar-delete:hover,
+.gpk-gem-avatar-delete:focus-visible {
+  background: rgba(32, 33, 36, 0.88);
+}
+
+.gpk-gem-avatar-preview:hover .gpk-gem-avatar-delete:not([hidden]),
+.gpk-gem-avatar-delete:focus-visible {
+  opacity: 1;
+}
+
+.gpk-gem-avatar-delete[hidden] {
+  display: none;
+}
+
+.gpk-gem-avatar-file-input {
+  display: none;
+}
+
+.gpk-gem-avatar-message {
+  position: absolute;
+  top: 0;
+  z-index: 3;
+  width: 40px;
+  height: 40px;
+  pointer-events: none;
+  box-shadow: 0 1px 3px rgba(60, 64, 67, 0.28);
+}
+
+.gpk-gem-avatar-message.gpk-gem-avatar-message-clickable {
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.gpk-gem-avatar-message.gpk-gem-avatar-message-clickable:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.gpk-gem-avatar-message-compact {
+  width: 32px;
+  height: 32px;
+}
+
+.gpk-gem-avatar-message-user {
+  right: -12px;
+  transform: translateX(100%);
+}
+
+.gpk-gem-avatar-message-model {
+  left: -12px;
+  transform: translateX(-100%);
+}
+
+.gpk-gem-avatar-message-user.gpk-gem-avatar-message-compact {
+  right: 0;
+}
+
+.gpk-gem-avatar-message-model.gpk-gem-avatar-message-compact {
+  left: 0;
+}
+
+.gpk-gem-avatar-edit-preview-scroller {
+  padding-left: 40px !important;
+  padding-right: 32px !important;
+}
+
+.gpk-gem-avatar-edit-preview-scroller .gpk-gem-avatar-message-model.gpk-gem-avatar-message-compact {
+  left: -4px;
+}

--- a/src/entrypoints/content/index.tsx
+++ b/src/entrypoints/content/index.tsx
@@ -16,6 +16,7 @@ import { enableBulkDelete } from '@/entrypoints/popup/storage'
 import { i18nCache } from '@/utils/i18nCache'
 import { stuffPageModule } from './stuff-page'
 import { initTheme, initThemeBackground } from './gemini-theme'
+import { gemAvatarModule } from './gem-avatar'
 import {
   FIREFOX_INSTANCE_ID_ATTR,
   markFirefoxReloadRequired,
@@ -126,6 +127,10 @@ export default defineContentScript({
     urlMonitor.start()
     console.log('[ContentScript] URL Monitor started')
 
+    // 2.1 Start Gem avatar module (depends on URL monitor events)
+    gemAvatarModule.start()
+    console.log('[ContentScript] Gem Avatar Module started')
+
     // 3. Then start chat change detector (depends on urlMonitor)
     chatChangeDetector.start()
     console.log('[ContentScript] Chat Change Detector started')
@@ -179,6 +184,7 @@ export default defineContentScript({
         )
       }
       bulkDeleteSettings.stop()
+      gemAvatarModule.stop()
       stopPowerKitEntry()
     })
     console.log('[ContentScript] UI mounted, context still valid:', ctx.isValid)

--- a/src/entrypoints/content/index.tsx
+++ b/src/entrypoints/content/index.tsx
@@ -12,11 +12,12 @@ import { chatChangeDetector } from '@/services/chatChangeDetector'
 import { urlMonitor } from '@/services/urlMonitor'
 import { tabTitleSync } from '@/services/tabTitleSync'
 import { startResponseCompleteNotificationContentProvider } from '@/services/responseCompleteNotificationContent'
-import { enableBulkDelete } from '@/entrypoints/popup/storage'
+import { enableBulkDelete, enableGemAvatar } from '@/entrypoints/popup/storage'
 import { i18nCache } from '@/utils/i18nCache'
 import { stuffPageModule } from './stuff-page'
 import { initTheme, initThemeBackground } from './gemini-theme'
 import { gemAvatarModule } from './gem-avatar'
+import { createGemAvatarSettingsController } from './gem-avatar/settings'
 import {
   FIREFOX_INSTANCE_ID_ATTR,
   markFirefoxReloadRequired,
@@ -127,10 +128,6 @@ export default defineContentScript({
     urlMonitor.start()
     console.log('[ContentScript] URL Monitor started')
 
-    // 2.1 Start Gem avatar module (depends on URL monitor events)
-    gemAvatarModule.start()
-    console.log('[ContentScript] Gem Avatar Module started')
-
     // 3. Then start chat change detector (depends on urlMonitor)
     chatChangeDetector.start()
     console.log('[ContentScript] Chat Change Detector started')
@@ -175,6 +172,12 @@ export default defineContentScript({
       stop: stopBulkDelete,
     })
     await bulkDeleteSettings.start()
+    const gemAvatarSettings = createGemAvatarSettingsController({
+      setting: enableGemAvatar,
+      start: () => gemAvatarModule.start(),
+      stop: () => gemAvatarModule.stop(),
+    })
+    await gemAvatarSettings.start()
     startPowerKitEntry()
     ctx.onInvalidated(() => {
       if (import.meta.env.DEV) {
@@ -184,7 +187,7 @@ export default defineContentScript({
         )
       }
       bulkDeleteSettings.stop()
-      gemAvatarModule.stop()
+      gemAvatarSettings.stop()
       stopPowerKitEntry()
     })
     console.log('[ContentScript] UI mounted, context still valid:', ctx.isValid)

--- a/src/entrypoints/popup/storage.ts
+++ b/src/entrypoints/popup/storage.ts
@@ -25,7 +25,7 @@ export const enableBulkDelete = storage.defineItem<boolean>(
 export const enableGemAvatar = storage.defineItem<boolean>(
   'sync:enableGemAvatar',
   {
-    fallback: true,
+    fallback: false,
   }
 );
 

--- a/src/entrypoints/popup/storage.ts
+++ b/src/entrypoints/popup/storage.ts
@@ -22,6 +22,13 @@ export const enableBulkDelete = storage.defineItem<boolean>(
   }
 );
 
+export const enableGemAvatar = storage.defineItem<boolean>(
+  'sync:enableGemAvatar',
+  {
+    fallback: true,
+  }
+);
+
 // Helper functions for individual settings
 export const getChatOutlineEnabled = () => enableChatOutline.getValue();
 export const setChatOutlineEnabled = (enabled: boolean) => enableChatOutline.setValue(enabled);
@@ -31,6 +38,9 @@ export const setQuickQuoteEnabled = (enabled: boolean) => enableQuickQuote.setVa
 
 export const getBulkDeleteEnabled = () => enableBulkDelete.getValue();
 export const setBulkDeleteEnabled = (enabled: boolean) => enableBulkDelete.setValue(enabled);
+
+export const getGemAvatarEnabled = () => enableGemAvatar.getValue();
+export const setGemAvatarEnabled = (enabled: boolean) => enableGemAvatar.setValue(enabled);
 
 // Helper function to get all settings at once
 export const getAllSettings = async () => {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -123,6 +123,10 @@
         "title": "Chat-Gliederung",
         "description": "Fügt eine anklickbare Gliederung hinzu, um lange Unterhaltungen leichter zu navigieren."
       },
+      "gemAvatar": {
+        "title": "Gem-Avatar",
+        "description": "Benutzerdefinierte Avatare für Ihre Gems aktivieren."
+      },
       "bulkDelete": {
         "title": "Massenlöschung",
         "description": "Wählen Sie mehrere Chats aus und löschen Sie sie auf einmal."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -123,6 +123,10 @@
         "title": "Chat Outline",
         "description": "Adds a clickable outline to help you navigate long conversations."
       },
+      "gemAvatar": {
+        "title": "Gem Avatar",
+        "description": "Use custom avatars for your Gems."
+      },
       "bulkDelete": {
         "title": "Bulk Delete",
         "description": "Select and delete multiple chats at once."

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -123,6 +123,10 @@
         "title": "Esquema de chat",
         "description": "Añade un esquema interactivo para navegar conversaciones largas."
       },
+      "gemAvatar": {
+        "title": "Avatar de Gem",
+        "description": "Usa avatares personalizados para tus Gems."
+      },
       "bulkDelete": {
         "title": "Eliminación en lote",
         "description": "Selecciona y elimina varios chats a la vez."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -123,6 +123,10 @@
         "title": "Plan de discussion",
         "description": "Ajoute un plan cliquable pour naviguer facilement dans les longues conversations."
       },
+      "gemAvatar": {
+        "title": "Avatar des Gems",
+        "description": "Utilisez des avatars personnalisés pour vos Gems."
+      },
       "bulkDelete": {
         "title": "Suppression groupée",
         "description": "Sélectionnez et supprimez plusieurs discussions à la fois."

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -123,6 +123,10 @@
         "title": "チャットアウトライン",
         "description": "長い会話を見やすくするクリック可能なアウトラインを追加します。"
       },
+      "gemAvatar": {
+        "title": "Gemアバター",
+        "description": "Gem にカスタムアバターを使います。"
+      },
       "bulkDelete": {
         "title": "一括削除",
         "description": "複数のチャットをまとめて選択・削除します。"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -123,6 +123,10 @@
         "title": "채팅 개요",
         "description": "긴 대화를 쉽게 탐색할 수 있는 클릭 가능한 개요를 추가합니다."
       },
+      "gemAvatar": {
+        "title": "Gem 아바타",
+        "description": "Gem에 사용자 지정 아바타를 사용합니다."
+      },
       "bulkDelete": {
         "title": "일괄 삭제",
         "description": "여러 채팅을 한 번에 선택하고 삭제합니다."

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -123,6 +123,10 @@
         "title": "Esboço de chat",
         "description": "Adiciona um esboço clicável para navegar por conversas longas."
       },
+      "gemAvatar": {
+        "title": "Avatar do Gem",
+        "description": "Use avatares personalizados nos seus Gems."
+      },
       "bulkDelete": {
         "title": "Exclusão em lote",
         "description": "Selecione e exclua várias conversas de uma só vez."

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -123,6 +123,10 @@
         "title": "聊天大纲",
         "description": "添加可点击的大纲，方便浏览长对话。"
       },
+      "gemAvatar": {
+        "title": "Gem 头像",
+        "description": "为你的 Gems 使用自定义头像。"
+      },
       "bulkDelete": {
         "title": "批量删除",
         "description": "一次选择并删除多条聊天记录。"

--- a/src/locales/zh_TW.json
+++ b/src/locales/zh_TW.json
@@ -123,6 +123,10 @@
         "title": "聊天大綱",
         "description": "加入可點擊的大綱，方便瀏覽較長的對話。"
       },
+      "gemAvatar": {
+        "title": "Gem 頭像",
+        "description": "為你的 Gems 使用自訂頭像。"
+      },
       "bulkDelete": {
         "title": "批次刪除",
         "description": "一次選取並刪除多則對話。"


### PR DESCRIPTION
## Summary

- add per-Gem avatar upload, storage, and rendering across chat, editor, and Gem list pages
- add an Enhancement setting, disabled by default, to control Gem Avatar at runtime
- immediately remove injected avatars and layout classes when the setting is disabled, then restore them when enabled again

## Why

Gem avatars let users visually distinguish customized Gems while preserving an opt-in, low-impact default experience.

## Validation

- `pnpm test:run` (291 tests)
- `pnpm compile`
- `pnpm run check:i18n`
- `git diff --check origin/main...HEAD`
