### PR TITLE
fix: clarify bulk delete entry

### DIFF
--- a/src/entrypoints/content/bulk-delete/BulkDeleteEntry.tsx
+++ b/src/entrypoints/content/bulk-delete/BulkDeleteEntry.tsx
@@ -1,4 +1,5 @@
-import { LuTrash, LuX } from 'react-icons/lu'
+import { LuX } from 'react-icons/lu'
+import { MdOutlineLibraryAddCheck } from 'react-icons/md'
 import { t } from '@/utils/i18n'
 
 interface BulkDeleteEntryProps {
@@ -20,7 +21,7 @@ export function BulkDeleteEntry({ active, onToggle }: BulkDeleteEntryProps) {
         onToggle()
       }}
     >
-      {active ? <LuX aria-hidden="true" size={16} /> : <LuTrash aria-hidden="true" size={16} />}
+      {active ? <LuX aria-hidden="true" size={16} /> : <MdOutlineLibraryAddCheck aria-hidden="true" size={16} />}
     </button>
   )
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -52,7 +52,7 @@
     "entryLabel": "Massenlöschung",
     "entryHint": {
       "title": "Mehrfach löschen",
-      "description": "Wähle mehrere Chats aus und lösche unerwünschte Unterhaltungen auf einmal.",
+      "description": "Tippe, um den Mehrfachauswahlmodus zu aktivieren. Wähle die Chats aus, die du löschen möchtest, und bestätige dann.",
       "dismiss": "Schließen"
     },
     "selectRecent": "Letzte $1 auswählen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,7 +52,7 @@
     "entryLabel": "Bulk delete",
     "entryHint": {
       "title": "Bulk Delete",
-      "description": "Select several chats, then clear unwanted conversations in one go.",
+      "description": "Click to enter multi-select mode. Select the chats you want to delete, then confirm.",
       "dismiss": "Dismiss"
     },
     "selectRecent": "Select $1 recent",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -52,7 +52,7 @@
     "entryLabel": "Eliminación en lote",
     "entryHint": {
       "title": "Eliminación masiva",
-      "description": "Selecciona varios chats y borra de una vez las conversaciones que no quieras.",
+      "description": "Pulsa para entrar en el modo de selección múltiple. Selecciona los chats que quieras borrar y confirma.",
       "dismiss": "Cerrar"
     },
     "selectRecent": "Seleccionar los últimos $1",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -52,7 +52,7 @@
     "entryLabel": "Suppression groupée",
     "entryHint": {
       "title": "Suppression groupée",
-      "description": "Sélectionnez plusieurs chats, puis supprimez d'un coup les conversations indésirables.",
+      "description": "Cliquez pour passer en mode multi-sélection. Sélectionnez les chats à supprimer, puis confirmez.",
       "dismiss": "Fermer"
     },
     "selectRecent": "Sélectionner les $1 dernières",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -52,7 +52,7 @@
     "entryLabel": "一括削除",
     "entryHint": {
       "title": "一括削除",
-      "description": "複数のチャットを選んで、不要な会話をまとめて削除できます。",
+      "description": "タップして複数選択モードを開始し、削除したいチャットを選んで確定します。",
       "dismiss": "閉じる"
     },
     "selectRecent": "最近の$1件を選択",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -52,7 +52,7 @@
     "entryLabel": "일괄 삭제",
     "entryHint": {
       "title": "일괄 삭제",
-      "description": "여러 채팅을 선택해 원치 않는 대화를 한 번에 정리하세요.",
+      "description": "다중 선택 모드로 들어가려면 누르세요. 삭제할 채팅을 선택한 다음 확인하세요.",
       "dismiss": "닫기"
     },
     "selectRecent": "최근 $1개 선택",

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -52,7 +52,7 @@
     "entryLabel": "Exclusão em lote",
     "entryHint": {
       "title": "Exclusão em massa",
-      "description": "Selecione vários chats e apague de uma vez as conversas indesejadas.",
+      "description": "Toque para entrar no modo de seleção múltipla. Selecione os chats que deseja excluir e confirme.",
       "dismiss": "Fechar"
     },
     "selectRecent": "Selecionar as últimas $1",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -52,7 +52,7 @@
     "entryLabel": "批量删除",
     "entryHint": {
       "title": "批量删除",
-      "description": "一次勾选多条对话，更快清理无用记录。",
+      "description": "点击进入多选模式。选择要删除的聊天，然后确认。",
       "dismiss": "关闭"
     },
     "selectRecent": "选择最近 $1 个",

--- a/src/locales/zh_TW.json
+++ b/src/locales/zh_TW.json
@@ -52,7 +52,7 @@
     "entryLabel": "批次刪除",
     "entryHint": {
       "title": "批次刪除",
-      "description": "一次勾選多則對話，更快清理不需要的紀錄。",
+      "description": "點擊進入多選模式。選擇要刪除的聊天室，然後確認。",
       "dismiss": "關閉"
     },
     "selectRecent": "選取最近 $1 則",


### PR DESCRIPTION
## Summary

- Replace the Bulk Delete entry's trash icon with a multi-select icon.
- Explain that clicking enters multi-select mode; deletion happens only after confirmation.
- Localize the revised onboarding hint in every supported locale.

## Why

The previous trash icon could be read as an immediate destructive action, creating unnecessary concern about accidental deletion.

## Validation

- `pnpm run check:i18n`
- `./node_modules/.bin/vitest run src/entrypoints/content/bulk-delete/BulkDeleteEntryHint.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check origin/main...HEAD`