### PR TITLE
fix: stabilize Power Kit side nav entry

### DIFF
--- a/src/entrypoints/content/power-kit-entry/README.md
+++ b/src/entrypoints/content/power-kit-entry/README.md
@@ -7,36 +7,38 @@ It supports:
 - Desktop side nav (`sidenav-mavatar-footer`, with legacy `side-nav-action-button` fallback)
 - Mobile/drawer controls (`button` list in `.mobile-controls`)
 
-Clicking the entry opens the extension theme settings panel via `eventBus`.
+Clicking the entry opens the extension Enhancements settings page via `eventBus`.
 
 ## File
 - `index.ts`: full implementation (DOM injection, sync, observers, tooltip lifecycle)
 
 ## How It Works
-1. Find the reference node (`Settings & help`) on desktop and mobile.
-2. Clone that node to preserve native layout/class/style.
-3. Replace icon/text/attrs to become `Gemini Power kit`.
-4. Insert the cloned entry right before `Settings & help`.
+1. Resolve the Gemini-owned placement anchor (`Settings & help`) and current desktop variant.
+2. Render the current mavatar entry as GPK-owned light DOM: container, native button, SVG, styles, tooltip, and click handler.
+3. Insert the owned entry before Settings when expanded, or as an aligned rail item above Settings when collapsed.
+4. Keep Gemini selectors and placement decisions at the adapter boundary; the entry never clones Gemini's custom elements, Angular attributes, classes, or event behavior.
 5. Keep syncing when Gemini rerenders side nav.
 
-## Open Theme Settings
+## Open Enhancements Settings
 The click handler emits:
 
 ```ts
 eventBus.emitSync('settings:open', {
   from: 'prompt-entrance',
   open: true,
-  module: 'theme',
+  module: 'enhancements',
 })
 ```
 
 ## Tooltip Strategy
-- Desktop collapsed state: use `tippy.js` tooltip with `gemini-tooltip` theme.
-- Desktop expanded state: no tooltip.
+- Desktop collapsed state: use `tippy.js` on the owned button, placed to the right.
+- Desktop expanded state: use `tippy.js` on the owned button, placed above.
 - Mobile entry: keeps native `title` tooltip behavior.
+- Desktop tooltips explicitly append to `document.body` so side-nav overflow cannot clip them.
 
 Desktop tooltip config (current):
-- `placement: 'top'`
+- `placement: 'right'` when collapsed, `'top'` when expanded
+- `appendTo: () => document.body`
 - `animation: 'shift-away-subtle'`
 - `arrow: false`
 - `duration: [null, 0]`
@@ -52,30 +54,34 @@ Tooltip lifecycle safety:
 - Destroy on variant switch (`collapsed -> expanded`).
 - Destroy on host replacement/removal.
 - Sweep detached/out-of-scope instances every sync.
-- Global cleanup on `beforeunload`.
+- Global cleanup on `beforeunload`, including observers, tooltip instances, injected DOM, and module-owned styles.
 
 ## Key Selectors / Test IDs
 - Desktop settings anchor:
+  - `gem-icon-button[data-test-id="mavatar-footer-settings-button"]`
   - `button[data-test-id="mavatar-footer-settings-button"]`
   - Legacy fallback: `side-nav-action-button[data-test-id="settings-and-help-button"]`
 - Mobile settings anchor:
   - `button[data-test-id="mobile-settings-and-help-control"]`
 - Injected desktop entry:
+  - `[data-test-id="gemini-power-kit-mavatar-container"]`
+  - `button[data-test-id="gemini-power-kit-button"]`
   - `side-nav-action-button[data-test-id="gemini-power-kit-button"]`
 - Injected mobile entry:
   - `button[data-test-id="mobile-gemini-power-kit-control"]`
 
 ## Maintenance Notes
 - Do not rely on visible text matching; structure selectors are primary.
-- Keep icon size aligned with Material icon button sizing (`20px` in collapsed desktop).
+- Gemini dependencies stop at placement and variant detection. Do not clone Gemini controls for the current mavatar entry.
+- Keep the owned host/button geometry aligned with Gemini (`32px` host, `36px` button, `20px` icon box).
 - Avoid re-binding click listeners: guarded by `data-gpk-bound`.
 - If Gemini updates DOM structure, update anchor selectors first.
 - Current desktop layout uses `.mavatar-footer-row.collapsed` for the rail state and a non-collapsed footer row for expanded state.
 
 ## Quick Verification Checklist
 1. Desktop collapsed: entry appears above `Settings & help`.
-2. Desktop collapsed hover: tooltip appears at top and hides on mouse leave.
-3. Desktop collapsed click: tooltip hides immediately and theme panel opens.
-4. Desktop expanded: label is visible and no tooltip is shown.
-5. Mobile/drawer: entry exists with icon + label, click opens theme panel.
+2. Desktop collapsed hover: tooltip appears to the right and is not clipped by the side nav.
+3. Desktop collapsed click: tooltip hides immediately and the Enhancements page opens.
+4. Desktop expanded: entry is aligned immediately before Settings and its tooltip appears above.
+5. Mobile/drawer: entry exists with icon + label, click opens the Enhancements page.
 6. Refresh/resize/expand-collapse loops do not duplicate entry.

--- a/src/entrypoints/content/power-kit-entry/README.zh-CN.md
+++ b/src/entrypoints/content/power-kit-entry/README.zh-CN.md
@@ -7,36 +7,38 @@
 - 桌面侧边栏（`sidenav-mavatar-footer`，并保留旧 `side-nav-action-button` fallback）
 - 移动端/抽屉控制区（`.mobile-controls` 下的 `button`）
 
-点击入口后，通过 `eventBus` 打开插件主题设置面板。
+点击入口后，通过 `eventBus` 打开插件的 **Enhancements** 页面。
 
 ## 文件
 - `index.ts`：完整实现（DOM 注入、同步、观察器、tooltip 生命周期）
 
 ## 实现流程
-1. 在桌面和移动端分别找到 `Settings & help` 参考节点。
-2. 克隆参考节点（继承原有布局、class 与样式）。
-3. 将图标、文案、属性改写为 `Gemini Power kit`。
-4. 将克隆节点插入到 `Settings & help` 之前。
+1. 解析 Gemini 所有的 `Settings & help` 定位锚点和当前桌面变体。
+2. 当前 mavatar 入口使用 GPK 自有 Light DOM 渲染：容器、原生 button、SVG、样式、tooltip 和点击事件。
+3. 展开态插入到 Settings 前；收起态作为对齐的 rail 项插入到 Settings 上方。
+4. Gemini 选择器与插入决策只存在于适配层；入口不克隆 Gemini 自定义元素、Angular 属性、class 或事件行为。
 5. 在 Gemini 侧边栏重绘后持续同步，保证入口不丢失、不重复。
 
-## 打开主题设置
+## 打开 Enhancements 页面
 点击处理触发：
 
 ```ts
 eventBus.emitSync('settings:open', {
   from: 'prompt-entrance',
   open: true,
-  module: 'theme',
+  module: 'enhancements',
 })
 ```
 
 ## Tooltip 策略
-- 桌面收起态：使用 `tippy.js`，沿用 `gemini-tooltip` 主题。
-- 桌面展开态：不显示 tooltip。
+- 桌面收起态：在自有 button 上使用 `tippy.js`，显示在右侧。
+- 桌面展开态：在自有 button 上使用 `tippy.js`，显示在上方。
 - 移动端入口：保留原生 `title` 行为。
+- 桌面 tooltip 明确挂载到 `document.body`，避免被 SideNav overflow 截断。
 
 当前桌面 tooltip 配置：
-- `placement: 'top'`
+- 收起态 `placement: 'right'`，展开态 `placement: 'top'`
+- `appendTo: () => document.body`
 - `animation: 'shift-away-subtle'`
 - `arrow: false`
 - `duration: [null, 0]`
@@ -52,30 +54,34 @@ tooltip 生命周期防护：
 - 变体切换（`collapsed -> expanded`）时销毁。
 - 宿主替换/移除时销毁。
 - 每轮同步清理断连或越界实例。
-- `beforeunload` 时全量清理。
+- `beforeunload` 时全量清理观察器、tooltip 实例、注入 DOM 和模块自有样式。
 
 ## 关键选择器 / Test ID
 - 桌面设置锚点：
+  - `gem-icon-button[data-test-id="mavatar-footer-settings-button"]`
   - `button[data-test-id="mavatar-footer-settings-button"]`
   - 旧版 fallback：`side-nav-action-button[data-test-id="settings-and-help-button"]`
 - 移动端设置锚点：
   - `button[data-test-id="mobile-settings-and-help-control"]`
 - 注入的桌面入口：
+  - `[data-test-id="gemini-power-kit-mavatar-container"]`
+  - `button[data-test-id="gemini-power-kit-button"]`
   - `side-nav-action-button[data-test-id="gemini-power-kit-button"]`
 - 注入的移动端入口：
   - `button[data-test-id="mobile-gemini-power-kit-control"]`
 
 ## 维护建议
 - 优先依赖结构选择器，不依赖文案匹配。
-- 折叠态图标尺寸需与 Material Icon Button 对齐（当前为 `20px`）。
+- Gemini 依赖止于定位和变体判断；当前 mavatar 入口禁止克隆 Gemini 控件。
+- 自有 host/button 几何尺寸需与 Gemini 对齐（`32px` host、`36px` button、`20px` icon box）。
 - 点击事件绑定使用 `data-gpk-bound` 防止重复绑定。
 - 如果 Gemini DOM 结构变动，先更新锚点选择器再看其他逻辑。
 - 当前桌面布局使用 `.mavatar-footer-row.collapsed` 判断收起态，去掉 `collapsed` 后为展开态。
 
 ## 快速验收清单
 1. 桌面收起态：入口出现在 `Settings & help` 上方。
-2. 桌面收起态 hover：tooltip 出现在上方，离开后消失。
-3. 桌面收起态点击：tooltip 立即隐藏，并打开主题设置面板。
-4. 桌面展开态：显示文字，不显示 tooltip。
-5. 移动端/抽屉：入口存在（图标+文案），点击可打开主题设置。
+2. 桌面收起态 hover：tooltip 出现在右侧，且不会被 SideNav 截断。
+3. 桌面收起态点击：tooltip 立即隐藏，并打开 **Enhancements** 页面。
+4. 桌面展开态：入口紧邻 Settings 前方对齐，tooltip 显示在上方。
+5. 移动端/抽屉：入口存在（图标+文案），点击可打开 **Enhancements** 页面。
 6. 刷新、改尺寸、展开/收起循环后，入口不重复、不丢失。

--- a/src/entrypoints/content/power-kit-entry/index.test.ts
+++ b/src/entrypoints/content/power-kit-entry/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { eventBus } from '@/utils/eventbus'
+import tippy from 'tippy.js'
 import { startPowerKitEntry, stopPowerKitEntry } from './index'
 
 vi.mock('@/utils/eventbus', () => ({
@@ -9,9 +10,10 @@ vi.mock('@/utils/eventbus', () => ({
 }))
 
 vi.mock('tippy.js', () => ({
-  default: vi.fn((reference: Element) => ({
+  default: vi.fn((reference: Element, options: unknown) => ({
     destroy: vi.fn(),
     hide: vi.fn(),
+    options,
     reference,
     setContent: vi.fn(),
     setProps: vi.fn(),
@@ -23,14 +25,14 @@ vi.mock('./badge', () => ({
   shouldShowBadge: vi.fn(() => Promise.resolve(false)),
 }))
 
-function renderMavatarFooter(): void {
+function renderMavatarFooter(collapsed = false): void {
   document.body.innerHTML = `
     <chat-app>
       <bard-sidenav>
         <side-navigation-content>
           <mat-action-list class="desktop-controls">
             <sidenav-mavatar-footer>
-              <div class="mavatar-footer-row">
+              <div class="mavatar-footer-row${collapsed ? ' collapsed' : ''}">
                 <a class="mavatar-footer-left" aria-label="Google Account: Test User">
                   <div class="mavatar-container"></div>
                   <div class="mavatar-user-info">
@@ -38,17 +40,19 @@ function renderMavatarFooter(): void {
                   </div>
                 </a>
                 <div class="mavatar-footer-right">
-                  <gem-icon-button
-                    class="mavatar-settings-button gem-button"
-                    data-test-id="mavatar-footer-settings-button"
-                    fonticonname="settings"
-                  >
-                    <button aria-label="Settings" aria-haspopup="menu" aria-expanded="false">
-                      <gem-icon>
-                        <mat-icon data-mat-icon-name="settings" fonticon="settings"></mat-icon>
-                      </gem-icon>
-                    </button>
-                  </gem-icon-button>
+                  <div class="mavatar-settings-button-wrapper">
+                    <gem-icon-button
+                      class="mavatar-settings-button gem-button"
+                      data-test-id="mavatar-footer-settings-button"
+                      fonticonname="settings"
+                    >
+                      <button aria-label="Settings" aria-haspopup="menu" aria-expanded="false">
+                        <gem-icon>
+                          <mat-icon data-mat-icon-name="settings" fonticon="settings"></mat-icon>
+                        </gem-icon>
+                      </button>
+                    </gem-icon-button>
+                  </div>
                 </div>
               </div>
             </sidenav-mavatar-footer>
@@ -118,31 +122,129 @@ describe('power kit entry', () => {
     vi.clearAllMocks()
   })
 
-  it('injects before the current Gemini mavatar gem-icon-button settings control', () => {
+  it('renders an owned light-DOM entry before Settings in expanded mode', () => {
     startPowerKitEntry()
 
     const settingsButton = document.querySelector(
       'gem-icon-button[data-test-id="mavatar-footer-settings-button"]'
     )
-    const powerKitButton = document.querySelector<HTMLElement>(
-      'gem-icon-button[data-test-id="gemini-power-kit-button"], button[data-test-id="gemini-power-kit-button"]'
+    const container = document.querySelector<HTMLElement>(
+      'div[data-test-id="gemini-power-kit-mavatar-container"]'
+    )
+    const powerKitButton = container?.querySelector<HTMLButtonElement>(
+      'button[data-test-id="gemini-power-kit-button"]'
     )
 
+    expect(container?.getAttribute('data-gpk-variant')).toBe('expanded')
+    expect(container?.nextElementSibling).toBe(settingsButton)
+    expect(container?.className).toBe('')
+    expect(container?.querySelector('gem-icon-button, mat-icon')).toBeNull()
     expect(powerKitButton).not.toBeNull()
-    expect(powerKitButton?.nextElementSibling).toBe(settingsButton)
-    const actionButton = powerKitButton?.matches('button')
-      ? powerKitButton
-      : powerKitButton?.querySelector('button')
-    expect(actionButton?.getAttribute('aria-label')).toBe('Gemini Power kit')
-    expect(actionButton?.hasAttribute('aria-haspopup')).toBe(false)
+    expect(powerKitButton?.getAttribute('aria-label')).toBe('Gemini Power kit')
+    expect(powerKitButton?.hasAttribute('aria-haspopup')).toBe(false)
+    expect(document.getElementById('gpk-side-nav-entry-style')?.textContent)
+      .toContain('[data-gpk-mavatar-entry-button]')
 
-    powerKitButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    powerKitButton?.click()
 
     expect(eventBus.emitSync).toHaveBeenCalledWith('settings:open', {
       from: 'prompt-entrance',
-      module: 'theme',
+      module: 'enhancements',
       open: true,
     })
+  })
+
+  it('refreshes stale injected CSS and removes all owned styles on stop', () => {
+    const staleEntryStyle = document.createElement('style')
+    staleEntryStyle.id = 'gpk-side-nav-entry-style'
+    staleEntryStyle.textContent = 'stale entry styles'
+    document.head.appendChild(staleEntryStyle)
+
+    const staleBadgeStyle = document.createElement('style')
+    staleBadgeStyle.id = 'gpk-badge-style'
+    document.head.appendChild(staleBadgeStyle)
+
+    startPowerKitEntry()
+
+    expect(staleEntryStyle.textContent).toContain('[data-gpk-mavatar-entry-button]')
+    expect(staleEntryStyle.textContent).not.toContain('stale entry styles')
+    expect(document.getElementById('gpk-tooltip-style')).not.toBeNull()
+
+    stopPowerKitEntry()
+
+    expect(document.getElementById('gpk-side-nav-entry-style')).toBeNull()
+    expect(document.getElementById('gpk-tooltip-style')).toBeNull()
+    expect(document.getElementById('gpk-badge-style')).toBeNull()
+  })
+
+  it('renders a self-contained aligned entry above Settings in collapsed mode', () => {
+    renderMavatarFooter(true)
+
+    startPowerKitEntry()
+
+    const footerRow = document.querySelector('.mavatar-footer-row')
+    const footerRight = document.querySelector('.mavatar-footer-right')
+    const container = document.querySelector<HTMLElement>(
+      'div[data-test-id="gemini-power-kit-mavatar-container"]'
+    )
+    const powerKitButton = container?.querySelector<HTMLButtonElement>(
+      'button[data-test-id="gemini-power-kit-button"]'
+    )
+
+    expect(container?.parentElement).toBe(footerRow)
+    expect(container?.previousElementSibling).toBe(footerRight)
+    expect(container?.getAttribute('data-gpk-variant')).toBe('collapsed')
+    expect(container?.getAttribute('data-gpk-mavatar-entry')).toBe('1')
+    expect(powerKitButton?.style.cssText).toBe('')
+
+    powerKitButton?.click()
+
+    expect(eventBus.emitSync).toHaveBeenCalledWith('settings:open', {
+      from: 'prompt-entrance',
+      module: 'enhancements',
+      open: true,
+    })
+  })
+
+  it('moves the same owned entry when Gemini changes between collapsed and expanded', async () => {
+    renderMavatarFooter(true)
+    startPowerKitEntry()
+
+    const footerRow = document.querySelector('.mavatar-footer-row')
+    const settingsButton = document.querySelector(
+      'gem-icon-button[data-test-id="mavatar-footer-settings-button"]'
+    )
+    const initialContainer = document.querySelector<HTMLElement>(
+      'div[data-test-id="gemini-power-kit-mavatar-container"]'
+    )
+
+    footerRow?.classList.remove('collapsed')
+    await flushAnimationFrame()
+    await flushAnimationFrame()
+
+    const currentContainer = document.querySelector<HTMLElement>(
+      'div[data-test-id="gemini-power-kit-mavatar-container"]'
+    )
+    expect(currentContainer).toBe(initialContainer)
+    expect(currentContainer?.nextElementSibling).toBe(settingsButton)
+    expect(currentContainer?.getAttribute('data-gpk-variant')).toBe('expanded')
+  })
+
+  it('portals the owned tooltip to document.body', () => {
+    renderMavatarFooter(true)
+    startPowerKitEntry()
+
+    const powerKitButton = document.querySelector(
+      'button[data-test-id="gemini-power-kit-button"]'
+    )
+    const tippyMock = vi.mocked(tippy)
+    const ownEntryCall = tippyMock.mock.calls.find(
+      ([reference]) => (reference as unknown) === powerKitButton
+    )
+    const options = ownEntryCall?.[1] as { appendTo?: () => Element; placement?: string } | undefined
+
+    expect(options?.placement).toBe('right')
+    expect(options?.appendTo?.()).toBe(document.body)
   })
 
   it('renders a fallback entry as the penultimate child of the footer right container', () => {
@@ -151,23 +253,25 @@ describe('power kit entry', () => {
     startPowerKitEntry()
 
     const footerRight = document.querySelector('.mavatar-footer-right')
-    const powerKitButton = document.querySelector<HTMLButtonElement>(
+    const container = document.querySelector<HTMLElement>(
+      'div[data-test-id="gemini-power-kit-mavatar-container"]'
+    )
+    const powerKitButton = container?.querySelector<HTMLButtonElement>(
       'button[data-test-id="gemini-power-kit-button"]'
     )
     const lastItem = document.querySelector('[data-test-id="last-right-item"]')
 
     expect(powerKitButton).not.toBeNull()
-    expect(powerKitButton?.parentElement).toBe(footerRight)
-    expect(powerKitButton?.nextElementSibling).toBe(lastItem)
-    expect(powerKitButton?.style.width).toBe('36px')
-    expect(powerKitButton?.style.height).toBe('36px')
+    expect(container?.parentElement).toBe(footerRight)
+    expect(container?.nextElementSibling).toBe(lastItem)
+    expect(container?.getAttribute('data-gpk-variant')).toBe('expanded')
     expect(powerKitButton?.querySelector('svg')?.getAttribute('data-gpk-icon-size')).toBe('18')
 
     powerKitButton?.click()
 
     expect(eventBus.emitSync).toHaveBeenCalledWith('settings:open', {
       from: 'prompt-entrance',
-      module: 'theme',
+      module: 'enhancements',
       open: true,
     })
   })
@@ -178,16 +282,17 @@ describe('power kit entry', () => {
     startPowerKitEntry()
 
     const footerRow = document.querySelector('.mavatar-footer-row')
-    const powerKitButton = document.querySelector<HTMLButtonElement>(
+    const container = document.querySelector<HTMLElement>(
+      'div[data-test-id="gemini-power-kit-mavatar-container"]'
+    )
+    const powerKitButton = container?.querySelector<HTMLButtonElement>(
       'button[data-test-id="gemini-power-kit-button"]'
     )
     const lastItem = document.querySelector('[data-test-id="last-row-item"]')
 
     expect(powerKitButton).not.toBeNull()
-    expect(powerKitButton?.parentElement).toBe(footerRow)
-    expect(powerKitButton?.nextElementSibling).toBe(lastItem)
-    expect(powerKitButton?.style.width).toBe('36px')
-    expect(powerKitButton?.style.height).toBe('36px')
+    expect(container?.parentElement).toBe(footerRow)
+    expect(container?.nextElementSibling).toBe(lastItem)
   })
 
   it('does not move the fallback entry again when it is already penultimate', async () => {
@@ -195,10 +300,10 @@ describe('power kit entry', () => {
     startPowerKitEntry()
 
     const footerRight = document.querySelector('.mavatar-footer-right')
-    const powerKitButton = document.querySelector<HTMLButtonElement>(
-      'button[data-test-id="gemini-power-kit-button"]'
+    const container = document.querySelector<HTMLElement>(
+      'div[data-test-id="gemini-power-kit-mavatar-container"]'
     )
-    if (!footerRight || !powerKitButton) {
+    if (!footerRight || !container) {
       throw new Error('fallback entry did not render')
     }
 
@@ -210,7 +315,7 @@ describe('power kit entry', () => {
 
     const trigger = document.createElement('span')
     trigger.setAttribute('data-test-id', 'before-power-kit-trigger')
-    footerRight.insertBefore(trigger, powerKitButton)
+    footerRight.insertBefore(trigger, container)
 
     await flushAnimationFrame()
     await flushAnimationFrame()
@@ -218,10 +323,10 @@ describe('power kit entry', () => {
 
     const powerKitMoved = records.some((record) => {
       const changedNodes = [...Array.from(record.addedNodes), ...Array.from(record.removedNodes)]
-      return changedNodes.includes(powerKitButton)
+      return changedNodes.includes(container)
     })
 
-    expect(powerKitButton.nextElementSibling?.getAttribute('data-test-id')).toBe('last-right-item')
+    expect(container.nextElementSibling?.getAttribute('data-test-id')).toBe('last-right-item')
     expect(powerKitMoved).toBe(false)
   })
 })

--- a/src/entrypoints/content/power-kit-entry/index.ts
+++ b/src/entrypoints/content/power-kit-entry/index.ts
@@ -10,8 +10,6 @@ const MOBILE_POWER_KIT_BUTTON_TEST_ID = 'mobile-gemini-power-kit-control'
 const MOBILE_SETTINGS_BUTTON_TEST_ID = 'mobile-settings-and-help-control'
 
 const POWER_KIT_LABEL = 'Gemini Power kit'
-const MAVATAR_FALLBACK_ENTRY_SIZE_PX = 36
-const MAVATAR_FALLBACK_ICON_SIZE_PX = 18
 const DEFAULT_POWER_KIT_ICON_SIZE_PX = 20
 const MAVATAR_POWER_KIT_ICON_SIZE_PX = 16
 const WIDE_MAVATAR_EXPANDED_POWER_KIT_ICON_SIZE_PX = 18
@@ -34,7 +32,7 @@ const SYNC_RELATED_SELECTOR = [
   `button[data-test-id="${DESKTOP_MAVATAR_SETTINGS_BUTTON_TEST_ID}"]`,
   `gem-icon-button[data-test-id="${DESKTOP_POWER_KIT_HOST_TEST_ID}"]`,
   `button[data-test-id="${DESKTOP_POWER_KIT_HOST_TEST_ID}"]`,
-  `div[data-test-id="${DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID}"]`,
+  `[data-test-id="${DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID}"]`,
   `button[data-test-id="${MOBILE_SETTINGS_BUTTON_TEST_ID}"]`,
   'sidenav-mavatar-footer',
   '.mavatar-footer-row',
@@ -48,18 +46,36 @@ type DesktopVariant = 'expanded' | 'collapsed'
 
 const BADGE_DOT_ATTR = 'data-gpk-badge'
 const BADGE_STYLE_ID = 'gpk-badge-style'
+const ENTRY_STYLE_ID = 'gpk-side-nav-entry-style'
 const TOOLTIP_STYLE_ID = 'gpk-tooltip-style'
+const MAVATAR_ENTRY_ATTR = 'data-gpk-mavatar-entry'
+const MAVATAR_ENTRY_BUTTON_ATTR = 'data-gpk-mavatar-entry-button'
+const MAVATAR_ENTRY_ICON_ATTR = 'data-gpk-mavatar-entry-icon'
 
 let badgeVisible = false
 
+const ensureInjectedStyle = (styleId: string, css: string) => {
+  let style = document.getElementById(styleId) as HTMLStyleElement | null
+  if (!style) {
+    style = document.createElement('style')
+    style.id = styleId
+    document.head.appendChild(style)
+  }
+
+  if (style.textContent !== css) {
+    style.textContent = css
+  }
+}
+
 const injectBadgeStyle = () => {
-  if (document.getElementById(BADGE_STYLE_ID)) return
-  const style = document.createElement('style')
-  style.id = BADGE_STYLE_ID
-  style.textContent = `
+  const css = `
 mat-icon[data-gpk-icon-applied="1"] {
   position: relative !important;
   overflow: visible !important;
+}
+[${MAVATAR_ENTRY_ICON_ATTR}] {
+  position: relative;
+  overflow: visible;
 }
 [${BADGE_DOT_ATTR}="icon"] {
   position: absolute;
@@ -90,7 +106,7 @@ mat-icon[data-gpk-icon-applied="1"] {
   font-family: inherit;
 }
 `
-  document.head.appendChild(style)
+  ensureInjectedStyle(BADGE_STYLE_ID, css)
 }
 
 const ensureBadgeDot = (el: HTMLElement, mode: 'icon' | 'inline') => {
@@ -122,11 +138,98 @@ const removeAllBadgeDots = () => {
 
 // ── End badge state ──────────────────────────────────────────────────────────
 
+const injectEntryStyle = () => {
+  const css = `
+[${MAVATAR_ENTRY_ATTR}] {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 32px;
+  width: 32px;
+  height: 32px;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  color: var(
+    --lumi-sys-color--on-surface,
+    var(--gem-sys-color--on-surface, currentColor)
+  );
+}
+
+[${MAVATAR_ENTRY_ATTR}][data-gpk-variant="collapsed"] {
+  margin: 4px;
+}
+
+[${MAVATAR_ENTRY_BUTTON_ATTR}] {
+  appearance: none;
+  -webkit-appearance: none;
+  box-sizing: border-box;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 36px;
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  margin: 0;
+  padding: 6px;
+  border: 0;
+  border-radius: 9999px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+  overflow: visible;
+  -webkit-tap-highlight-color: transparent;
+}
+
+[${MAVATAR_ENTRY_BUTTON_ATTR}]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: currentColor;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+[${MAVATAR_ENTRY_BUTTON_ATTR}]:hover::before {
+  opacity: 0.08;
+}
+
+[${MAVATAR_ENTRY_BUTTON_ATTR}]:focus-visible::before {
+  opacity: 0.12;
+}
+
+[${MAVATAR_ENTRY_BUTTON_ATTR}]:active::before {
+  opacity: 0.12;
+}
+
+[${MAVATAR_ENTRY_BUTTON_ATTR}]:focus-visible {
+  outline: 2px solid var(--gem-sys-color--primary, currentColor);
+  outline-offset: 2px;
+}
+
+[${MAVATAR_ENTRY_ICON_ATTR}] {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 20px;
+  width: 20px;
+  height: 20px;
+  pointer-events: none;
+}
+`
+  ensureInjectedStyle(ENTRY_STYLE_ID, css)
+}
+
 const injectTooltipStyle = () => {
-  if (document.getElementById(TOOLTIP_STYLE_ID)) return
-  const style = document.createElement('style')
-  style.id = TOOLTIP_STYLE_ID
-  style.textContent = `
+  const css = `
 .tippy-box[data-theme~='gemini-tooltip'] {
   background: rgb(0, 0, 0);
   border-radius: 12px;
@@ -147,7 +250,7 @@ body.dark-theme .tippy-box[data-theme~='gemini-tooltip'] {
   padding: 8px 16px;
 }
 `
-  document.head.appendChild(style)
+  ensureInjectedStyle(TOOLTIP_STYLE_ID, css)
 }
 
 let rafId: number | null = null
@@ -194,11 +297,11 @@ const getSideNavRoot = (): HTMLElement | null => document.querySelector('side-na
 
 const getLayoutRoot = (): HTMLElement | null => document.querySelector('chat-app')
 
-const openThemeSettings = () => {
+const openEnhancementsSettings = () => {
   eventBus.emitSync('settings:open', {
     from: 'prompt-entrance',
     open: true,
-    module: 'theme',
+    module: 'enhancements',
   })
 }
 
@@ -220,26 +323,7 @@ const setTextIfDifferent = (el: Element, value: string) => {
   }
 }
 
-const syncAttributesFromSource = (
-  source: Element,
-  target: Element,
-  preservedAttrs: readonly string[] = []
-) => {
-  const preserved = new Set(preservedAttrs)
-  const sourceAttrNames = new Set(Array.from(source.attributes).map((attr) => attr.name))
-
-  for (const attr of Array.from(target.attributes)) {
-    if (!sourceAttrNames.has(attr.name) && !preserved.has(attr.name)) {
-      target.removeAttribute(attr.name)
-    }
-  }
-
-  for (const attr of Array.from(source.attributes)) {
-    setAttrIfDifferent(target, attr.name, attr.value)
-  }
-}
-
-const bindThemeOpenHandler = (button: HTMLElement) => {
+const bindSettingsOpenHandler = (button: HTMLElement) => {
   if (button.dataset.gpkBound === '1') return
   button.dataset.gpkBound = '1'
   button.addEventListener('click', (event) => {
@@ -252,7 +336,7 @@ const bindThemeOpenHandler = (button: HTMLElement) => {
       removeAllBadgeDots()
       void dismissBadge()
     }
-    openThemeSettings()
+    openEnhancementsSettings()
   })
 }
 
@@ -303,6 +387,7 @@ const ensureDesktopTooltip = (
 
   try {
     const instance = tippy(button, {
+      appendTo: () => document.body,
       content: POWER_KIT_LABEL,
       placement,
       animation: 'shift-away-subtle',
@@ -336,16 +421,6 @@ const sweepDesktopTooltipInstances = () => {
       desktopTooltipInstances.delete(instance)
     }
   }
-}
-
-const getElementPixelSize = (element: Element | null, fallbackPx = DEFAULT_POWER_KIT_ICON_SIZE_PX) => {
-  if (!(element instanceof HTMLElement)) return fallbackPx
-
-  const rect = element.getBoundingClientRect()
-  if (rect.width > 0) return Math.round(rect.width)
-
-  const fontSize = Number.parseFloat(getComputedStyle(element).fontSize)
-  return Number.isFinite(fontSize) && fontSize > 0 ? Math.round(fontSize) : fallbackPx
 }
 
 const isVisibleElement = (element: Element | null) => {
@@ -412,7 +487,7 @@ const decorateDesktopEntry = (host: HTMLElement, variant: DesktopVariant) => {
   htmlButton.style.setProperty('--mat-icon-button-icon-size', '20px')
   removeAttrIfPresent(button, 'aria-haspopup')
   removeAttrIfPresent(button, 'aria-expanded')
-  bindThemeOpenHandler(button as HTMLElement)
+  bindSettingsOpenHandler(button as HTMLElement)
 
   const icon = host.querySelector('mat-icon[data-test-id="side-nav-action-button-icon"], mat-icon')
   applyPowerKitSvgIcon(icon)
@@ -446,104 +521,72 @@ const getDesktopMavatarVariant = (settingsButton: HTMLElement): DesktopVariant =
   return sideNav?.classList.contains('collapsed') ? 'collapsed' : 'expanded'
 }
 
-const getDesktopMavatarPowerKitButton = (): HTMLElement | null =>
-  document.querySelector(
-    `gem-icon-button[data-test-id="${DESKTOP_POWER_KIT_HOST_TEST_ID}"], button[data-test-id="${DESKTOP_POWER_KIT_HOST_TEST_ID}"]`
-  )
-
 const getDesktopMavatarPowerKitContainer = (): HTMLElement | null =>
-  document.querySelector(`div[data-test-id="${DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID}"]`)
+  document.querySelector(`[data-test-id="${DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID}"]`)
 
-const getDesktopMavatarFallbackPowerKitButton = (): HTMLButtonElement | null =>
-  document.querySelector(`button[data-test-id="${DESKTOP_POWER_KIT_HOST_TEST_ID}"]`)
+const getOrCreateDesktopMavatarPowerKitContainer = () => {
+  const existing = getDesktopMavatarPowerKitContainer()
+  if (existing?.matches(`div[${MAVATAR_ENTRY_ATTR}]`)) {
+    return existing
+  }
 
-const decorateDesktopMavatarButton = (
-  button: HTMLElement,
-  sourceClassName: string,
-  variant: DesktopVariant,
-  sourceIconSizePx: number
+  existing?.remove()
+  return document.createElement('div')
+}
+
+const getDesktopMavatarIconSize = (
+  variant: DesktopVariant
 ) => {
-  setAttrIfDifferent(button, 'data-test-id', DESKTOP_POWER_KIT_HOST_TEST_ID)
-  setAttrIfDifferent(button, 'aria-label', POWER_KIT_LABEL)
-  removeAttrIfPresent(button, 'title')
-  setAttrIfDifferent(button, 'data-gpk-variant', variant)
-  if (button.className !== sourceClassName) {
-    button.className = sourceClassName
-  }
-  removeAttrIfPresent(button, 'aria-haspopup')
-  removeAttrIfPresent(button, 'aria-expanded')
-  bindThemeOpenHandler(button)
-
-  const innerButton = button.matches('button') ? button : button.querySelector('button')
-  if (innerButton) {
-    setAttrIfDifferent(innerButton, 'aria-label', POWER_KIT_LABEL)
-    removeAttrIfPresent(innerButton, 'title')
-    removeAttrIfPresent(innerButton, 'aria-haspopup')
-    removeAttrIfPresent(innerButton, 'aria-expanded')
-  }
-
-  const icon = button.querySelector('mat-icon')
   const useNarrowIconSize = variant === 'expanded' && isNarrowMavatarLayout()
-  const iconSizePx = variant === 'collapsed'
+  return variant === 'collapsed'
     ? MAVATAR_POWER_KIT_ICON_SIZE_PX
     : useNarrowIconSize
       ? NARROW_MAVATAR_POWER_KIT_ICON_SIZE_PX
       : WIDE_MAVATAR_EXPANDED_POWER_KIT_ICON_SIZE_PX
-  const iconBoxSizePx = variant === 'collapsed' ? DEFAULT_POWER_KIT_ICON_SIZE_PX : sourceIconSizePx
-  applyPowerKitSvgIcon(icon, iconSizePx, iconBoxSizePx)
-
-  const iconTarget = (button.querySelector('mat-icon[data-gpk-icon-applied="1"]') ?? icon) as HTMLElement | null
-  if (iconTarget) ensureBadgeDot(iconTarget, 'icon')
-
-  ensureDesktopTooltip(button, true, variant === 'collapsed' ? 'right' : 'top')
 }
 
-const decorateDesktopMavatarFallbackButton = (
-  button: HTMLButtonElement,
-  iconSizePx: number
+const decorateDesktopMavatarEntry = (
+  container: HTMLElement,
+  variant: DesktopVariant
 ) => {
+  injectEntryStyle()
+  setAttrIfDifferent(container, 'data-test-id', DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID)
+  setAttrIfDifferent(container, MAVATAR_ENTRY_ATTR, '1')
+  setAttrIfDifferent(container, 'data-gpk-variant', variant)
+
+  let button = container.querySelector<HTMLButtonElement>(
+    `button[${MAVATAR_ENTRY_BUTTON_ATTR}]`
+  )
+  if (!button) {
+    button = document.createElement('button')
+    button.type = 'button'
+    button.setAttribute(MAVATAR_ENTRY_BUTTON_ATTR, '1')
+    button.setAttribute('data-test-id', DESKTOP_POWER_KIT_HOST_TEST_ID)
+    button.setAttribute('aria-label', POWER_KIT_LABEL)
+    container.replaceChildren(button)
+    bindSettingsOpenHandler(button)
+  }
+
   setAttrIfDifferent(button, 'data-test-id', DESKTOP_POWER_KIT_HOST_TEST_ID)
   setAttrIfDifferent(button, 'aria-label', POWER_KIT_LABEL)
-  setAttrIfDifferent(button, 'title', POWER_KIT_LABEL)
-  setAttrIfDifferent(button, 'data-gpk-variant', 'fallback')
-  button.type = 'button'
-  button.className = 'gpk-power-kit-fallback-entry'
-  button.style.width = `${MAVATAR_FALLBACK_ENTRY_SIZE_PX}px`
-  button.style.height = `${MAVATAR_FALLBACK_ENTRY_SIZE_PX}px`
-  button.style.minWidth = `${MAVATAR_FALLBACK_ENTRY_SIZE_PX}px`
-  button.style.padding = '0'
-  button.style.border = '0'
-  button.style.borderRadius = '50%'
-  button.style.background = 'transparent'
-  button.style.color = 'inherit'
-  button.style.display = 'inline-flex'
-  button.style.alignItems = 'center'
-  button.style.justifyContent = 'center'
-  button.style.cursor = 'pointer'
-  removeAttrIfPresent(button, 'aria-haspopup')
-  removeAttrIfPresent(button, 'aria-expanded')
-  bindThemeOpenHandler(button)
+  removeAttrIfPresent(button, 'title')
+  bindSettingsOpenHandler(button)
 
-  let icon = button.querySelector('span[data-gpk-fallback-icon="1"]')
+  let icon = button.querySelector<HTMLElement>(`span[${MAVATAR_ENTRY_ICON_ATTR}]`)
   if (!icon) {
     icon = document.createElement('span')
-    icon.setAttribute('data-gpk-fallback-icon', '1')
-    button.replaceChildren(icon)
+    icon.setAttribute(MAVATAR_ENTRY_ICON_ATTR, '1')
+    button.appendChild(icon)
   }
-  if (icon instanceof HTMLElement) {
-    icon.style.width = `${iconSizePx}px`
-    icon.style.height = `${iconSizePx}px`
-    icon.style.display = 'inline-flex'
-    icon.style.alignItems = 'center'
-    icon.style.justifyContent = 'center'
-  }
+
+  const iconSizePx = getDesktopMavatarIconSize(variant)
   if (icon.getAttribute('data-gpk-icon-size') !== String(iconSizePx)) {
     icon.innerHTML = getPowerKitIconSvg(iconSizePx)
     icon.setAttribute('data-gpk-icon-size', String(iconSizePx))
   }
-  if (icon instanceof HTMLElement) ensureBadgeDot(icon, 'icon')
+  ensureBadgeDot(icon, 'icon')
 
-  ensureDesktopTooltip(button, true, 'top')
+  ensureDesktopTooltip(button, true, variant === 'collapsed' ? 'right' : 'top')
 }
 
 const insertAsPenultimateChild = (parent: HTMLElement, child: HTMLElement) => {
@@ -575,28 +618,24 @@ const ensureDesktopMavatarFallbackEntry = () => {
 
   bindDesktopObservers(mountParent, footerRow ?? mountParent)
 
-  const existingPowerKitEntry = getDesktopMavatarPowerKitButton()
-  if (existingPowerKitEntry && !existingPowerKitEntry.matches('button')) {
-    destroyDesktopTooltip(existingPowerKitEntry)
-    existingPowerKitEntry.remove()
+  const container = getOrCreateDesktopMavatarPowerKitContainer()
+  const variant: DesktopVariant = footerRow?.classList.contains('collapsed')
+    ? 'collapsed'
+    : 'expanded'
+  decorateDesktopMavatarEntry(container, variant)
+
+  if (variant === 'collapsed' && footerRow && footerRight) {
+    if (
+      container.parentElement !== footerRow
+      || container.previousElementSibling !== footerRight
+    ) {
+      footerRow.insertBefore(container, footerRight.nextElementSibling)
+    }
+  } else {
+    insertAsPenultimateChild(mountParent, container)
   }
 
-  const existingButton = getDesktopMavatarFallbackPowerKitButton()
-  const currentButton = existingButton ?? document.createElement('button')
-  decorateDesktopMavatarFallbackButton(currentButton, MAVATAR_FALLBACK_ICON_SIZE_PX)
-  insertAsPenultimateChild(mountParent, currentButton)
-
   return true
-}
-
-const buildDesktopMavatarButtonFromSettings = (
-  settingsButton: HTMLElement,
-  variant: DesktopVariant,
-  sourceIconSizePx: number
-) => {
-  const clone = settingsButton.cloneNode(true) as HTMLElement
-  decorateDesktopMavatarButton(clone, settingsButton.className, variant, sourceIconSizePx)
-  return clone
 }
 
 const ensureDesktopMavatarEntry = () => {
@@ -611,35 +650,25 @@ const ensureDesktopMavatarEntry = () => {
   bindDesktopObservers(settingsButton, footerRow)
 
   const variant = getDesktopMavatarVariant(settingsButton)
-  const sourceIconSizePx = getElementPixelSize(settingsButton.querySelector('mat-icon'))
-  const existingButton = getDesktopMavatarPowerKitButton()
-  const isFallbackButton = Boolean(existingButton?.classList.contains('gpk-power-kit-fallback-entry'))
-  if (existingButton && isFallbackButton) {
-    destroyDesktopTooltip(existingButton)
-    existingButton.remove()
-  }
-  const existingContainer = getDesktopMavatarPowerKitContainer()
-  const currentButton = existingButton && !isFallbackButton
-    ? existingButton
-    : buildDesktopMavatarButtonFromSettings(settingsButton, variant, sourceIconSizePx)
-
-  decorateDesktopMavatarButton(currentButton, settingsButton.className, variant, sourceIconSizePx)
+  const container = getOrCreateDesktopMavatarPowerKitContainer()
+  decorateDesktopMavatarEntry(container, variant)
 
   if (variant === 'collapsed') {
-    const container = existingContainer ?? settingsButtonParent.cloneNode(false) as HTMLElement
-    syncAttributesFromSource(settingsButtonParent, container, ['data-test-id'])
-    setAttrIfDifferent(container, 'data-test-id', DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID)
-    if (currentButton.parentElement !== container) {
-      container.appendChild(currentButton)
-    }
-    if (container.parentElement !== footerRow || container.previousElementSibling !== settingsButtonParent) {
-      footerRow.insertBefore(container, settingsButtonParent.nextElementSibling)
+    const footerRight = settingsButton.closest('.mavatar-footer-right')
+    const insertionAnchor = footerRight ?? settingsButtonParent
+    if (
+      container.parentElement !== footerRow
+      || container.previousElementSibling !== insertionAnchor
+    ) {
+      footerRow.insertBefore(container, insertionAnchor.nextElementSibling)
     }
   } else {
-    if (currentButton.parentElement !== settingsButtonParent || currentButton.nextElementSibling !== settingsButton) {
-      settingsButtonParent.insertBefore(currentButton, settingsButton)
+    if (
+      container.parentElement !== settingsButtonParent
+      || container.nextElementSibling !== settingsButton
+    ) {
+      settingsButtonParent.insertBefore(container, settingsButton)
     }
-    existingContainer?.remove()
   }
 
   return true
@@ -690,7 +719,7 @@ const decorateMobileEntry = (button: HTMLButtonElement, sourceClassName: string)
   if (button.className !== sourceClassName) {
     button.className = sourceClassName
   }
-  bindThemeOpenHandler(button)
+  bindSettingsOpenHandler(button)
 
   const icon = button.querySelector('mat-icon')
   applyPowerKitSvgIcon(icon)
@@ -974,11 +1003,17 @@ const stopObservers = () => {
 const removeInjectedEntries = () => {
   document.querySelectorAll([
     POWER_KIT_ENTRY_SELECTOR,
-    `div[data-test-id="${DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID}"]`,
+    `[data-test-id="${DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID}"]`,
   ].join(',')).forEach((element) => {
     element.remove()
   })
   removeAllBadgeDots()
+}
+
+const removeInjectedStyles = () => {
+  for (const styleId of [BADGE_STYLE_ID, ENTRY_STYLE_ID, TOOLTIP_STYLE_ID]) {
+    document.getElementById(styleId)?.remove()
+  }
 }
 
 export const stopPowerKitEntry = () => {
@@ -988,6 +1023,7 @@ export const stopPowerKitEntry = () => {
   window.removeEventListener('beforeunload', stopPowerKitEntry)
   stopObservers()
   removeInjectedEntries()
+  removeInjectedStyles()
 }
 
 export const startPowerKitEntry = () => {


### PR DESCRIPTION
## Summary
- replace the current mavatar entry with owned Light DOM and independent styling/event handling
- align collapsed and expanded placement with Gemini while routing clicks to Enhancements
- clean up and refresh injected styles across content-script reinjection

## Validation
- pnpm test:run
- pnpm compile
- pnpm build