### PR TITLE
fix(shortcuts): enable hotkeys in prompt editor

### DIFF
--- a/src/services/shortcuts/definitions.test.ts
+++ b/src/services/shortcuts/definitions.test.ts
@@ -9,20 +9,27 @@ import {
 } from './definitions'
 
 describe('shortcut definitions', () => {
-  it('defines SideNav navigation shortcuts', () => {
-    const definitionsByAction = new Map(shortcutDefinitions.map((definition) => [definition.action, definition]))
+  it('allows every action except Focus Input to run while the prompt editor is focused', () => {
+    for (const definition of shortcutDefinitions) {
+      expect(definition.enableOnContentEditable).toBe(definition.action !== 'focusInput')
+      expect(
+        definition.enableOnFormTags === true
+        || (
+          Array.isArray(definition.enableOnFormTags)
+          && definition.enableOnFormTags.includes('textbox')
+        ),
+      ).toBe(definition.action !== 'focusInput')
+    }
 
+    const definitionsByAction = new Map(shortcutDefinitions.map((definition) => [definition.action, definition]))
     expect(definitionsByAction.get('openLibrary')).toMatchObject({
       defaultShortcut: { default: 'alt+l', mac: 'ctrl+l' },
-      enableOnContentEditable: false,
     })
     expect(definitionsByAction.get('openGems')).toMatchObject({
       defaultShortcut: { default: 'alt+g', mac: 'ctrl+g' },
-      enableOnContentEditable: false,
     })
     expect(definitionsByAction.get('toggleSidebar')).toMatchObject({
       defaultShortcut: { default: 'alt+b', mac: 'ctrl+b' },
-      enableOnContentEditable: false,
     })
   })
 
@@ -127,8 +134,8 @@ describe('shortcut definitions', () => {
     expect(bulkDelete).toMatchObject({
       category: 'geminiPowerKit',
       defaultShortcut: { default: 'alt+shift+d', mac: 'ctrl+shift+d' },
-      enableOnFormTags: ['input'],
-      enableOnContentEditable: false,
+      enableOnFormTags: ['input', 'textbox'],
+      enableOnContentEditable: true,
     })
 
     const checkbox = document.createElement('input')

--- a/src/services/shortcuts/definitions.ts
+++ b/src/services/shortcuts/definitions.ts
@@ -60,22 +60,24 @@ function withPlatformModifier(defaultKeys: string, macKeys = defaultKeys): Short
   }
 }
 
+const promptEditorFormTags = ['textbox'] as const
+
 export const shortcutDefinitions: ShortcutDefinition[] = [
   {
     action: 'openSettings',
     category: 'geminiPowerKit',
     labelKey: 'settingPanel.shortcut.actions.openSettings',
     defaultShortcut: withPlatformModifier('comma'),
-    enableOnFormTags: false,
-    enableOnContentEditable: false,
+    enableOnFormTags: promptEditorFormTags,
+    enableOnContentEditable: true,
   },
   {
     action: 'toggleBulkDelete',
     category: 'geminiPowerKit',
     labelKey: 'settingPanel.shortcut.actions.toggleBulkDelete',
     defaultShortcut: withPlatformModifier('shift+d'),
-    enableOnFormTags: ['input'],
-    enableOnContentEditable: false,
+    enableOnFormTags: ['input', ...promptEditorFormTags],
+    enableOnContentEditable: true,
     ignoreEventWhen: (event) => (
       event.target instanceof HTMLInputElement && event.target.type !== 'checkbox'
     ),
@@ -85,40 +87,40 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'app',
     labelKey: 'settingPanel.shortcut.actions.toggleSidebar',
     defaultShortcut: withPlatformModifier('b'),
-    enableOnFormTags: false,
-    enableOnContentEditable: false,
+    enableOnFormTags: promptEditorFormTags,
+    enableOnContentEditable: true,
   },
   {
     action: 'openNewChat',
     category: 'app',
     labelKey: 'settingPanel.shortcut.actions.openNewChat',
     defaultShortcut: withPlatformModifier('n'),
-    enableOnFormTags: false,
-    enableOnContentEditable: false,
+    enableOnFormTags: promptEditorFormTags,
+    enableOnContentEditable: true,
   },
   {
     action: 'openTemporaryChat',
     category: 'app',
     labelKey: 'settingPanel.shortcut.actions.openTemporaryChat',
     defaultShortcut: withPlatformModifier('t'),
-    enableOnFormTags: false,
-    enableOnContentEditable: false,
+    enableOnFormTags: promptEditorFormTags,
+    enableOnContentEditable: true,
   },
   {
     action: 'openLibrary',
     category: 'app',
     labelKey: 'settingPanel.shortcut.actions.openLibrary',
     defaultShortcut: withPlatformModifier('l'),
-    enableOnFormTags: false,
-    enableOnContentEditable: false,
+    enableOnFormTags: promptEditorFormTags,
+    enableOnContentEditable: true,
   },
   {
     action: 'openGems',
     category: 'app',
     labelKey: 'settingPanel.shortcut.actions.openGems',
     defaultShortcut: withPlatformModifier('g'),
-    enableOnFormTags: false,
-    enableOnContentEditable: false,
+    enableOnFormTags: promptEditorFormTags,
+    enableOnContentEditable: true,
   },
   {
     action: 'focusInput',
@@ -133,7 +135,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'prompt',
     labelKey: 'settingPanel.shortcut.actions.toggleSpeechDictation',
     defaultShortcut: withPlatformModifier('d'),
-    enableOnFormTags: ['textbox'],
+    enableOnFormTags: promptEditorFormTags,
     enableOnContentEditable: true,
   },
   {
@@ -141,7 +143,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'prompt',
     labelKey: 'settingPanel.shortcut.actions.cycleModel',
     defaultShortcut: withPlatformModifier('m', 'shift+m'),
-    enableOnFormTags: ['textbox'],
+    enableOnFormTags: promptEditorFormTags,
     enableOnContentEditable: true,
   },
   {
@@ -149,7 +151,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'prompt',
     labelKey: 'settingPanel.shortcut.actions.uploadFiles',
     defaultShortcut: withPlatformModifier('u'),
-    enableOnFormTags: ['textbox'],
+    enableOnFormTags: promptEditorFormTags,
     enableOnContentEditable: true,
   },
   {
@@ -157,7 +159,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'prompt',
     labelKey: 'settingPanel.shortcut.actions.createImage',
     defaultShortcut: withPlatformModifier('shift+i', 'i'),
-    enableOnFormTags: ['textbox'],
+    enableOnFormTags: promptEditorFormTags,
     enableOnContentEditable: true,
   },
   {
@@ -165,7 +167,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'prompt',
     labelKey: 'settingPanel.shortcut.actions.createVideo',
     defaultShortcut: withPlatformModifier('shift+v', 'v'),
-    enableOnFormTags: ['textbox'],
+    enableOnFormTags: promptEditorFormTags,
     enableOnContentEditable: true,
   },
   {
@@ -173,7 +175,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'prompt',
     labelKey: 'settingPanel.shortcut.actions.createMusic',
     defaultShortcut: withPlatformModifier('shift+m', 'm'),
-    enableOnFormTags: ['textbox'],
+    enableOnFormTags: promptEditorFormTags,
     enableOnContentEditable: true,
   },
   {
@@ -181,7 +183,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'prompt',
     labelKey: 'settingPanel.shortcut.actions.openCanvas',
     defaultShortcut: withPlatformModifier('shift+c', 'c'),
-    enableOnFormTags: ['textbox'],
+    enableOnFormTags: promptEditorFormTags,
     enableOnContentEditable: true,
   },
   {
@@ -189,7 +191,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     category: 'prompt',
     labelKey: 'settingPanel.shortcut.actions.openDeepResearch',
     defaultShortcut: withPlatformModifier('shift+r', 'r'),
-    enableOnFormTags: ['textbox'],
+    enableOnFormTags: promptEditorFormTags,
     enableOnContentEditable: true,
   },
 ]


### PR DESCRIPTION
## Summary

- Enable all page shortcuts except Focus Input while the Gemini prompt editor is focused.
- Allow the editor's `textbox` role as well as its `contenteditable` state.
- Preserve normal `/` input when the editor is already focused.

## Root cause

`react-hotkeys-hook` filters form-role targets before checking `contenteditable`. Gemini's editor has both `role="textbox"` and `contenteditable="true"`, so enabling only the latter did not allow the shortcut event through.

## Validation

- `pnpm test:run src/services/shortcuts` (30 tests)
- `pnpm compile`
- `git diff --check`

Related to #43