### PR TITLE
fix(ui): polish Theme styles and Top bar tooltips

### DIFF
--- a/src/entrypoints/content/gemini-theme/background/style.css
+++ b/src/entrypoints/content/gemini-theme/background/style.css
@@ -337,6 +337,10 @@
   background: var(--gem-sys-color--surface-bright);
 }
 
+:root[data-gpk-bg-enabled="true"] .autosuggest-scrim {
+  background: none;
+}
+
 :root[data-gpk-bg-enabled="true"] div.blur-bg.visible-primary-message.blur-shown {
   visibility: hidden !important;
 }

--- a/src/entrypoints/content/gemini-theme/background/styleController.test.ts
+++ b/src/entrypoints/content/gemini-theme/background/styleController.test.ts
@@ -294,6 +294,20 @@ describe('styleController', () => {
     expect(css).toContain('!important')
   })
 
+  it('removes the autosuggest scrim when a wallpaper is enabled', () => {
+    const css = readFileSync(
+      join(
+        process.cwd(),
+        'src/entrypoints/content/gemini-theme/background/style.css',
+      ),
+      'utf8',
+    )
+
+    expect(css).toMatch(
+      /:root\[data-gpk-bg-enabled="true"\] \.autosuggest-scrim \{\s*background: none;/,
+    )
+  })
+
   it('keeps the luminous mode sidenav transparent when a background is enabled', () => {
     const css = readFileSync(
       join(

--- a/src/entrypoints/content/gemini-tooltip.ts
+++ b/src/entrypoints/content/gemini-tooltip.ts
@@ -1,0 +1,121 @@
+import tippy, { type Instance } from 'tippy.js'
+
+export type GeminiTooltipPlacement = 'top' | 'right' | 'bottom' | 'left'
+export type GeminiTooltipOwner = 'power-kit-entry' | 'top-bar-action'
+
+export interface GeminiTooltipOptions {
+  content: string
+  owner: GeminiTooltipOwner
+  placement: GeminiTooltipPlacement
+}
+
+const TOOLTIP_STYLE_ID = 'gpk-tooltip-style'
+
+const TOOLTIP_CSS = `
+.tippy-box[data-theme~='gemini-tooltip'] {
+  background: rgb(0, 0, 0);
+  border-radius: 12px;
+  box-shadow: none;
+  color: rgb(242, 240, 240);
+  font-family: "Google Sans Flex", "Google Sans Text", "Google Sans", sans-serif;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+}
+
+body.dark-theme .tippy-box[data-theme~='gemini-tooltip'] {
+  background: rgb(230, 230, 230);
+  color: rgb(23, 23, 23);
+}
+
+.tippy-box[data-theme~='gemini-tooltip'] > .tippy-content {
+  padding: 8px 16px;
+}
+`
+
+interface TooltipRecord {
+  instance: Instance
+  owner: GeminiTooltipOwner
+}
+
+const tooltipInstances = new Map<HTMLElement, TooltipRecord>()
+
+const ensureTooltipStyle = () => {
+  let style = document.getElementById(TOOLTIP_STYLE_ID) as HTMLStyleElement | null
+  if (!style) {
+    style = document.createElement('style')
+    style.id = TOOLTIP_STYLE_ID
+    document.head.appendChild(style)
+  }
+
+  if (style.textContent !== TOOLTIP_CSS) {
+    style.textContent = TOOLTIP_CSS
+  }
+}
+
+const removeTooltipStyleIfUnused = () => {
+  if (tooltipInstances.size === 0) {
+    document.getElementById(TOOLTIP_STYLE_ID)?.remove()
+  }
+}
+
+export const getGeminiTooltip = (reference: HTMLElement): Instance | null =>
+  tooltipInstances.get(reference)?.instance ?? null
+
+export const createGeminiTooltip = (
+  reference: HTMLElement,
+  options: GeminiTooltipOptions,
+): Instance | null => {
+  ensureTooltipStyle()
+
+  const existing = tooltipInstances.get(reference)
+  if (existing) {
+    existing.instance.setContent(options.content)
+    existing.instance.setProps({ placement: options.placement })
+    return existing.instance
+  }
+
+  try {
+    const instance = tippy(reference, {
+      appendTo: () => document.body,
+      content: options.content,
+      placement: options.placement,
+      animation: 'shift-away-subtle',
+      arrow: false,
+      theme: 'gemini-tooltip',
+      duration: [null, 0],
+    })
+    tooltipInstances.set(reference, {
+      instance,
+      owner: options.owner,
+    })
+    return instance
+  } catch (error) {
+    console.warn('[Gemini Power kit] Failed to initialize tooltip', error)
+    removeTooltipStyleIfUnused()
+    return null
+  }
+}
+
+export const destroyGeminiTooltip = (reference: HTMLElement | null) => {
+  if (!reference) return
+  const record = tooltipInstances.get(reference)
+  if (!record) return
+
+  record.instance.destroy()
+  tooltipInstances.delete(reference)
+  removeTooltipStyleIfUnused()
+}
+
+export const destroyGeminiTooltipsWhere = (
+  shouldDestroy: (
+    reference: HTMLElement,
+    owner: GeminiTooltipOwner,
+  ) => boolean,
+) => {
+  for (const [reference, record] of Array.from(tooltipInstances.entries())) {
+    if (shouldDestroy(reference, record.owner)) {
+      destroyGeminiTooltip(reference)
+    }
+  }
+}

--- a/src/entrypoints/content/power-kit-entry/index.test.ts
+++ b/src/entrypoints/content/power-kit-entry/index.test.ts
@@ -210,6 +210,10 @@ describe('power kit entry', () => {
     renderMavatarFooter(true)
     startPowerKitEntry()
 
+    const tooltip = vi.mocked(tippy).mock.results[0]?.value as {
+      setProps: ReturnType<typeof vi.fn>
+    } | undefined
+
     const footerRow = document.querySelector('.mavatar-footer-row')
     const settingsButton = document.querySelector(
       'gem-icon-button[data-test-id="mavatar-footer-settings-button"]'
@@ -228,6 +232,7 @@ describe('power kit entry', () => {
     expect(currentContainer).toBe(initialContainer)
     expect(currentContainer?.nextElementSibling).toBe(settingsButton)
     expect(currentContainer?.getAttribute('data-gpk-variant')).toBe('expanded')
+    expect(tooltip?.setProps).toHaveBeenCalledWith({ placement: 'top' })
   })
 
   it('portals the owned tooltip to document.body', () => {

--- a/src/entrypoints/content/power-kit-entry/index.ts
+++ b/src/entrypoints/content/power-kit-entry/index.ts
@@ -1,5 +1,10 @@
 import { eventBus } from '@/utils/eventbus'
-import tippy, { type Instance } from 'tippy.js'
+import {
+  createGeminiTooltip,
+  destroyGeminiTooltip,
+  destroyGeminiTooltipsWhere,
+  getGeminiTooltip,
+} from '../gemini-tooltip'
 import { shouldShowBadge, dismissBadge } from './badge'
 
 const DESKTOP_POWER_KIT_HOST_TEST_ID = 'gemini-power-kit-button'
@@ -47,7 +52,6 @@ type DesktopVariant = 'expanded' | 'collapsed'
 const BADGE_DOT_ATTR = 'data-gpk-badge'
 const BADGE_STYLE_ID = 'gpk-badge-style'
 const ENTRY_STYLE_ID = 'gpk-side-nav-entry-style'
-const TOOLTIP_STYLE_ID = 'gpk-tooltip-style'
 const MAVATAR_ENTRY_ATTR = 'data-gpk-mavatar-entry'
 const MAVATAR_ENTRY_BUTTON_ATTR = 'data-gpk-mavatar-entry-button'
 const MAVATAR_ENTRY_ICON_ATTR = 'data-gpk-mavatar-entry-icon'
@@ -228,31 +232,6 @@ const injectEntryStyle = () => {
   ensureInjectedStyle(ENTRY_STYLE_ID, css)
 }
 
-const injectTooltipStyle = () => {
-  const css = `
-.tippy-box[data-theme~='gemini-tooltip'] {
-  background: rgb(0, 0, 0);
-  border-radius: 12px;
-  box-shadow: none;
-  color: rgb(242, 240, 240);
-  font-family: "Google Sans Flex", "Google Sans Text", "Google Sans", sans-serif;
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 16px;
-}
-
-body.dark-theme .tippy-box[data-theme~='gemini-tooltip'] {
-  background: rgb(230, 230, 230);
-  color: rgb(23, 23, 23);
-}
-
-.tippy-box[data-theme~='gemini-tooltip'] > .tippy-content {
-  padding: 8px 16px;
-}
-`
-  ensureInjectedStyle(TOOLTIP_STYLE_ID, css)
-}
-
 let rafId: number | null = null
 let bootstrapRetryTimer: number | null = null
 let bootstrapRetryCount = 0
@@ -271,7 +250,6 @@ let observedDesktopList: Element | null = null
 let observedDesktopSettingsHost: Element | null = null
 let observedMobileControls: Element | null = null
 
-const desktopTooltipInstances = new Set<Instance>()
 let isStarted = false
 
 const getDesktopSettingsHost = (): HTMLElement | null =>
@@ -340,17 +318,13 @@ const bindSettingsOpenHandler = (button: HTMLElement) => {
   })
 }
 
-const getDesktopTooltipInstance = (button: HTMLElement): Instance | null => {
-  const existing = (button as unknown as { _tippy?: Instance })._tippy
-  return existing ?? null
-}
+const getDesktopTooltipInstance = (button: HTMLElement) => getGeminiTooltip(button)
 
 const destroyDesktopTooltip = (button: HTMLElement | null) => {
   if (!button) return
   const existing = getDesktopTooltipInstance(button)
   if (!existing) return
-  existing.destroy()
-  desktopTooltipInstances.delete(existing)
+  destroyGeminiTooltip(button)
 }
 
 const POWER_KIT_ENTRY_SELECTOR = [
@@ -365,62 +339,22 @@ const ensureDesktopTooltip = (
   enabled: boolean,
   placement: 'top' | 'right' = 'top'
 ) => {
-  injectTooltipStyle()
-  const existing = getDesktopTooltipInstance(button)
-
   if (!enabled) {
-    if (existing) {
-      existing.destroy()
-      desktopTooltipInstances.delete(existing)
-    }
+    destroyGeminiTooltip(button)
     return
   }
 
-  if (existing) {
-    if (!desktopTooltipInstances.has(existing)) {
-      desktopTooltipInstances.add(existing)
-    }
-    existing.setContent(POWER_KIT_LABEL)
-    existing.setProps({ placement })
-    return
-  }
-
-  try {
-    const instance = tippy(button, {
-      appendTo: () => document.body,
-      content: POWER_KIT_LABEL,
-      placement,
-      animation: 'shift-away-subtle',
-      arrow: false,
-      theme: 'gemini-tooltip',
-      duration: [null, 0],
-    })
-
-    desktopTooltipInstances.add(instance)
-  } catch (error) {
-    console.warn('[Gemini Power kit] Failed to initialize desktop tooltip', error)
-  }
-}
-
-const destroyAllDesktopTooltips = () => {
-  for (const instance of desktopTooltipInstances) {
-    instance.destroy()
-  }
-  desktopTooltipInstances.clear()
+  createGeminiTooltip(button, {
+    content: POWER_KIT_LABEL,
+    owner: 'power-kit-entry',
+    placement,
+  })
 }
 
 const sweepDesktopTooltipInstances = () => {
-  for (const instance of Array.from(desktopTooltipInstances)) {
-    const reference = instance.reference as Element | null
-    const isDetached = !reference || !(reference as Node).isConnected
-    const outsidePowerKitEntry = !isDetached
-      && !reference.closest(POWER_KIT_ENTRY_SELECTOR)
-
-    if (isDetached || outsidePowerKitEntry) {
-      instance.destroy()
-      desktopTooltipInstances.delete(instance)
-    }
-  }
+  destroyGeminiTooltipsWhere((reference, owner) =>
+    owner === 'power-kit-entry' && !reference.isConnected
+  )
 }
 
 const isVisibleElement = (element: Element | null) => {
@@ -530,7 +464,12 @@ const getOrCreateDesktopMavatarPowerKitContainer = () => {
     return existing
   }
 
-  existing?.remove()
+  if (existing) {
+    destroyGeminiTooltipsWhere((reference, owner) =>
+      owner === 'power-kit-entry' && existing.contains(reference)
+    )
+    existing.remove()
+  }
   return document.createElement('div')
 }
 
@@ -558,6 +497,9 @@ const decorateDesktopMavatarEntry = (
     `button[${MAVATAR_ENTRY_BUTTON_ATTR}]`
   )
   if (!button) {
+    destroyGeminiTooltipsWhere((reference, owner) =>
+      owner === 'power-kit-entry' && container.contains(reference)
+    )
     button = document.createElement('button')
     button.type = 'button'
     button.setAttribute(MAVATAR_ENTRY_BUTTON_ATTR, '1')
@@ -826,7 +768,9 @@ const syncEntries = () => {
   }
 
   if (!desktopOk) {
-    destroyAllDesktopTooltips()
+    destroyGeminiTooltipsWhere((_reference, owner) =>
+      owner === 'power-kit-entry'
+    )
     unbindDesktopObservers()
   }
   if (!mobileOk) {
@@ -997,7 +941,9 @@ const stopObservers = () => {
   }
   bootstrapRetryCount = 0
 
-  destroyAllDesktopTooltips()
+  destroyGeminiTooltipsWhere((_reference, owner) =>
+    owner === 'power-kit-entry'
+  )
 }
 
 const removeInjectedEntries = () => {
@@ -1005,13 +951,16 @@ const removeInjectedEntries = () => {
     POWER_KIT_ENTRY_SELECTOR,
     `[data-test-id="${DESKTOP_MAVATAR_POWER_KIT_CONTAINER_TEST_ID}"]`,
   ].join(',')).forEach((element) => {
+    destroyGeminiTooltipsWhere((reference, owner) =>
+      owner === 'power-kit-entry' && element.contains(reference)
+    )
     element.remove()
   })
   removeAllBadgeDots()
 }
 
 const removeInjectedStyles = () => {
-  for (const styleId of [BADGE_STYLE_ID, ENTRY_STYLE_ID, TOOLTIP_STYLE_ID]) {
+  for (const styleId of [BADGE_STYLE_ID, ENTRY_STYLE_ID]) {
     document.getElementById(styleId)?.remove()
   }
 }

--- a/src/entrypoints/content/top-bar-action/index.test.ts
+++ b/src/entrypoints/content/top-bar-action/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { eventBus } from '@/utils/eventbus'
+import tippy from 'tippy.js'
 import {
   startChatSettingsTopBarAction,
   startTopBarAction,
@@ -15,6 +16,17 @@ vi.mock('@/utils/eventbus', () => ({
 
 vi.mock('@/utils/i18n', () => ({
   tt: (_key: string, fallback: string) => fallback,
+}))
+
+vi.mock('tippy.js', () => ({
+  default: vi.fn((reference: Element, options: unknown) => ({
+    destroy: vi.fn(),
+    hide: vi.fn(),
+    options,
+    reference,
+    setContent: vi.fn(),
+    setProps: vi.fn(),
+  })),
 }))
 
 const ENTRY_SELECTOR = '[data-test-id="gemini-power-kit-theme-top-bar-container"]'
@@ -75,8 +87,18 @@ describe('Theme top bar action', () => {
     expect(entry?.className).toBe('buttons-container')
     expect(entry?.nextElementSibling).toBe(lastNativeChild)
     expect(button?.getAttribute('aria-label')).toBe('Theme')
-    expect(button?.getAttribute('title')).toBe('Theme')
+    expect(button?.hasAttribute('title')).toBe(false)
     expect(button?.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 24 24')
+
+    const tooltipCall = vi.mocked(tippy).mock.calls[0]
+    const tooltipOptions = tooltipCall?.[1] as {
+      appendTo?: () => Element
+      content?: string
+      placement?: string
+    } | undefined
+    expect(tooltipOptions?.content).toBe('Theme')
+    expect(tooltipOptions?.placement).toBe('bottom')
+    expect(tooltipOptions?.appendTo?.()).toBe(document.body)
 
     button?.click()
 
@@ -157,6 +179,10 @@ describe('Theme top bar action', () => {
   it('rebinds and restores the entry when Gemini replaces the right section', async () => {
     startTopBarAction()
 
+    const initialTooltip = vi.mocked(tippy).mock.results[0]?.value as {
+      destroy: ReturnType<typeof vi.fn>
+    } | undefined
+
     const topBar = document.querySelector('top-bar-actions .top-bar-actions')
     const previousRightSection = document.querySelector('.right-section')
     const nextRightSection = document.createElement('div')
@@ -171,6 +197,7 @@ describe('Theme top bar action', () => {
     expect(topBar?.contains(nextRightSection)).toBe(true)
     expect(entry).not.toBeNull()
     expect(entry?.nextElementSibling?.getAttribute('data-native')).toBe('replacement')
+    expect(initialTooltip?.destroy).toHaveBeenCalledTimes(1)
   })
 
   it('repositions the entry when Gemini appends a native action', async () => {
@@ -211,6 +238,9 @@ describe('Theme top bar action', () => {
 
   it('removes resources and cancels pending work when stopped', async () => {
     startTopBarAction()
+    const tooltip = vi.mocked(tippy).mock.results[0]?.value as {
+      destroy: ReturnType<typeof vi.fn>
+    } | undefined
     const rightSection = document.querySelector('.right-section')
     rightSection?.appendChild(document.createElement('div'))
 
@@ -219,6 +249,7 @@ describe('Theme top bar action', () => {
 
     expect(document.querySelector(ENTRY_SELECTOR)).toBeNull()
     expect(document.getElementById('gpk-theme-top-bar-action-style')).toBeNull()
+    expect(tooltip?.destroy).toHaveBeenCalledTimes(1)
 
     rightSection?.appendChild(document.createElement('div'))
     await flushReconcile()

--- a/src/entrypoints/content/top-bar-action/index.ts
+++ b/src/entrypoints/content/top-bar-action/index.ts
@@ -1,6 +1,11 @@
 import chatWidthIconSvg from '@/assets/chat-width.svg?raw'
 import { eventBus } from '@/utils/eventbus'
 import { tt } from '@/utils/i18n'
+import {
+  createGeminiTooltip,
+  destroyGeminiTooltip,
+  destroyGeminiTooltipsWhere,
+} from '../gemini-tooltip'
 
 const APP_ROOT_SELECTOR = 'chat-app-orchestrator#app-root'
 const CHAT_APP_SELECTOR = 'chat-app'
@@ -226,7 +231,16 @@ function decorateEntry(container: HTMLElement, kind: EntryKind): void {
 
   setAttributeIfDifferent(container, 'class', 'buttons-container')
   setAttributeIfDifferent(button, 'aria-label', label)
-  setAttributeIfDifferent(button, 'title', label)
+  button.removeAttribute('title')
+  createGeminiTooltip(button, {
+    content: label,
+    owner: 'top-bar-action',
+    placement: 'bottom',
+  })
+}
+
+function destroyEntryTooltip(entry: Element, buttonSelector: string): void {
+  destroyGeminiTooltip(entry.querySelector<HTMLElement>(buttonSelector))
 }
 
 function isEntryNode(node: Node): boolean {
@@ -366,10 +380,16 @@ function ensureEntry(
     ? existingEntry
     : createEntry(kind)
 
-  if (existingEntry && existingEntry !== entry) existingEntry.remove()
+  if (existingEntry && existingEntry !== entry) {
+    destroyEntryTooltip(existingEntry, entrySelectors.button)
+    existingEntry.remove()
+  }
   document.querySelectorAll<HTMLElement>(entrySelectors.entry).forEach(
     (candidate) => {
-      if (candidate !== entry) candidate.remove()
+      if (candidate !== entry) {
+        destroyEntryTooltip(candidate, entrySelectors.button)
+        candidate.remove()
+      }
     },
   )
   decorateEntry(entry, kind)
@@ -401,6 +421,10 @@ function insertEntries(
 function reconcile(): void {
   if (!isStarted) return
 
+  destroyGeminiTooltipsWhere((reference, owner) => {
+    if (owner !== 'top-bar-action') return false
+    return !reference.isConnected || !reference.closest(ALL_ENTRY_SELECTOR)
+  })
   ensureObserverBindings()
   const rightSection = getRightSection()
   if (!rightSection) return
@@ -447,6 +471,9 @@ function stopObservers(): void {
 }
 
 function removeInjectedResources(): void {
+  destroyGeminiTooltipsWhere((_reference, owner) =>
+    owner === 'top-bar-action'
+  )
   document.querySelectorAll(ALL_ENTRY_SELECTOR)
     .forEach((entry) => entry.remove())
   document.getElementById(STYLE_ID)?.remove()
@@ -488,8 +515,10 @@ export function startTopBarAction(): void {
 export function stopTopBarAction(): void {
   if (!themeEnabled) return
   themeEnabled = false
-  document.querySelectorAll(THEME_ENTRY_SELECTOR)
-    .forEach((entry) => entry.remove())
+  document.querySelectorAll<HTMLElement>(THEME_ENTRY_SELECTOR).forEach((entry) => {
+    destroyEntryTooltip(entry, THEME_BUTTON_SELECTOR)
+    entry.remove()
+  })
   if (chatSettingsEnabled) reconcile()
   stopLifecycleIfUnused()
 }
@@ -503,8 +532,10 @@ export function startChatSettingsTopBarAction(): void {
 export function stopChatSettingsTopBarAction(): void {
   if (!chatSettingsEnabled) return
   chatSettingsEnabled = false
-  document.querySelectorAll(CHAT_SETTINGS_ENTRY_SELECTOR)
-    .forEach((entry) => entry.remove())
+  document.querySelectorAll<HTMLElement>(CHAT_SETTINGS_ENTRY_SELECTOR).forEach((entry) => {
+    destroyEntryTooltip(entry, CHAT_SETTINGS_TOP_BAR_BUTTON_SELECTOR)
+    entry.remove()
+  })
   eventBus.emitSync('chat-settings-panel:close', {
     source: 'shortcut-hidden',
   })


### PR DESCRIPTION
## What changed

- Fix Theme style adaptation for edge-case Gemini layouts.
- Add consistent tooltips to Top bar icon buttons.
- Centralize tooltip creation, updates, and cleanup for the Power Kit entry and Top bar actions.
- Add regression coverage for tooltip placement and lifecycle cleanup.

## User impact

Theme and Power Kit entry tooltips remain stable when Gemini replaces DOM nodes, switches layouts, or enables/disables entries. Top bar icon buttons now provide consistent hover and focus hints.

## Validation

- `pnpm test:run src/entrypoints/content/power-kit-entry/index.test.ts src/entrypoints/content/top-bar-action/index.test.ts`
- `pnpm compile`
- `git diff --check`