### PR TITLE
Fix bulk delete entry disappearing from Gemini

### DIFF
--- a/src/entrypoints/content/bulk-delete/BulkDeleteEntry.tsx
+++ b/src/entrypoints/content/bulk-delete/BulkDeleteEntry.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useRef } from 'react'
 import { LuX } from 'react-icons/lu'
 import { MdOutlineLibraryAddCheck } from 'react-icons/md'
 import { t } from '@/utils/i18n'
+import { createGeminiTooltip, destroyGeminiTooltip } from '../gemini-tooltip'
 
 interface BulkDeleteEntryProps {
   active: boolean
@@ -8,12 +10,31 @@ interface BulkDeleteEntryProps {
 }
 
 export function BulkDeleteEntry({ active, onToggle }: BulkDeleteEntryProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    const button = buttonRef.current
+    if (!button) {
+      return
+    }
+
+    createGeminiTooltip(button, {
+      content: t('bulkDelete.entryLabel'),
+      owner: 'bulk-delete',
+      placement: 'right',
+    })
+
+    return () => {
+      destroyGeminiTooltip(button)
+    }
+  }, [])
+
   return (
     <button
+      ref={buttonRef}
       type="button"
       className="gpk-bulk-delete-entry-button"
       aria-label={t('bulkDelete.entryLabel')}
-      title={t('bulkDelete.entryLabel')}
       aria-pressed={active}
       onClick={(event) => {
         event.preventDefault()

--- a/src/entrypoints/content/bulk-delete/dom.ts
+++ b/src/entrypoints/content/bulk-delete/dom.ts
@@ -1,6 +1,17 @@
 import { t } from '@/utils/i18n'
 
-export const CHAT_HEADER_SELECTOR = 'side-navigation-content > div > div > infinite-scroller > expandable-section[storagekey="chats"][data-test-id="chats-expandable-section"] > button.expandable-section-header'
+const CHAT_SECTION_SELECTORS = [
+  'expandable-section[data-test-id="chats-expandable-section"]',
+  'expandable-section[storagekey="chats"]',
+]
+const SIDENAV_SELECTOR = 'bard-sidenav[role="navigation"], bard-sidenav'
+const CHAT_HEADER_SELECTORS = [
+  'button[data-test-id="expandable-section-toggle"]',
+  'button[aria-controls="sidenav-section-content-chats"]',
+  'button[aria-expanded]',
+  'button.expandable-section-header',
+]
+const CONVERSATION_LIST_SELECTOR = 'conversations-list[data-test-id="all-conversations"], conversations-list, gem-nav-list-item[data-test-id="conversation"]'
 
 const ENTRY_SPACER_ATTR = 'data-gpk-bulk-delete-entry-spacer'
 const ENTRY_ROOT_ATTR = 'data-gpk-bulk-delete-entry-root'
@@ -66,13 +77,61 @@ export interface LoadRowsResult {
   reason?: 'scroller-not-found' | 'timeout' | 'gemini-load-failed'
 }
 
+function isSectionHeaderToggle(section: HTMLElement, header: HTMLElement): boolean {
+  const container = header.parentElement
+  return container === section || container?.parentElement === section
+}
+
+function getSidenavScopes(root: ParentNode): ParentNode[] {
+  const sidenavs = Array.from(root.querySelectorAll<HTMLElement>(SIDENAV_SELECTOR))
+  return sidenavs.length > 0 ? sidenavs : [root]
+}
+
+function findChatSections(scope: ParentNode): HTMLElement[] {
+  const chatSections = CHAT_SECTION_SELECTORS.flatMap(selector =>
+    Array.from(scope.querySelectorAll<HTMLElement>(selector)),
+  )
+  const conversationList = scope.querySelector<HTMLElement>(CONVERSATION_LIST_SELECTOR)
+  const conversationSection = conversationList?.closest<HTMLElement>('expandable-section')
+  if (conversationSection && !chatSections.includes(conversationSection)) {
+    chatSections.push(conversationSection)
+  }
+  return chatSections
+}
+
 export function findChatHeader(root: ParentNode = document): HTMLElement | null {
-  return root.querySelector<HTMLElement>(CHAT_HEADER_SELECTOR)
+  for (const scope of getSidenavScopes(root)) {
+    for (const section of findChatSections(scope)) {
+      for (const selector of CHAT_HEADER_SELECTORS) {
+        const header = Array.from(section.querySelectorAll<HTMLElement>(selector))
+          .find(candidate => isSectionHeaderToggle(section, candidate))
+        if (header) {
+          return header
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+function getEntryContainer(header: HTMLElement): HTMLElement {
+  const headerActions = Array.from(header.parentElement?.children ?? [])
+    .find((element): element is HTMLElement =>
+      element instanceof HTMLElement && element.classList.contains('expandable-section-header-actions'),
+    )
+  return headerActions ?? header
 }
 
 export function ensureEntryMount(header: HTMLElement): HTMLElement {
-  const existing = header.querySelector<HTMLElement>(`[${ENTRY_ROOT_ATTR}]`)
+  const container = getEntryContainer(header)
+  const existing = container.querySelector<HTMLElement>(`[${ENTRY_ROOT_ATTR}]`)
+    ?? header.querySelector<HTMLElement>(`[${ENTRY_ROOT_ATTR}]`)
   if (existing) {
+    const spacer = existing.closest<HTMLElement>(`[${ENTRY_SPACER_ATTR}]`)
+    if (spacer && spacer.parentElement !== container) {
+      container.prepend(spacer)
+    }
     return existing
   }
 
@@ -82,7 +141,7 @@ export function ensureEntryMount(header: HTMLElement): HTMLElement {
   const root = document.createElement('div')
   root.setAttribute(ENTRY_ROOT_ATTR, 'true')
   spacer.appendChild(root)
-  header.appendChild(spacer)
+  container.prepend(spacer)
   return root
 }
 
@@ -90,8 +149,12 @@ export function removeEntryMount(root: HTMLElement): void {
   root.closest(`[${ENTRY_SPACER_ATTR}]`)?.remove()
 }
 
+function getBulkMenuAnchor(header: HTMLElement): HTMLElement {
+  return header.closest<HTMLElement>('.expandable-section-header-row') ?? header
+}
+
 export function findBulkMenu(header: HTMLElement): HTMLElement | null {
-  const next = header.nextElementSibling
+  const next = getBulkMenuAnchor(header).nextElementSibling
   if (next instanceof HTMLElement && next.hasAttribute(MENU_ATTR)) {
     return next
   }
@@ -215,7 +278,7 @@ export function ensureBulkMenu(
   recentRow.append(selectRecent, changeLimit)
   actionRow.append(deselectPinned, cancel)
   menu.append(recentRow, limitPanel, actionRow, submit)
-  header.insertAdjacentElement('afterend', menu)
+  getBulkMenuAnchor(header).insertAdjacentElement('afterend', menu)
   return menu
 }
 

--- a/src/entrypoints/content/bulk-delete/index.test.tsx
+++ b/src/entrypoints/content/bulk-delete/index.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import tippy from 'tippy.js'
 import {
   cleanupChatCheckboxes,
   ensureBulkMenu,
@@ -31,6 +32,17 @@ vi.mock('@/components/ui/toaster', () => ({
   },
 }))
 
+vi.mock('tippy.js', () => ({
+  default: vi.fn((reference: Element, options: unknown) => ({
+    destroy: vi.fn(),
+    hide: vi.fn(),
+    options,
+    reference,
+    setContent: vi.fn(),
+    setProps: vi.fn(),
+  })),
+}))
+
 vi.mock('@/utils/i18n', () => ({
   t: (id: string, substitutions?: string | string[]) => {
     if (id === 'bulkDelete.deleteSelected') {
@@ -38,6 +50,7 @@ vi.mock('@/utils/i18n', () => ({
       return `Delete (${count})`
     }
     const map: Record<string, string> = {
+      'bulkDelete.entryLabel': 'Bulk delete',
       'bulkDelete.selectRecent': `Select ${substitutions} recent`,
       'bulkDelete.selectUnpinned': `Select ${substitutions} unpinned`,
       'bulkDelete.excludePinned': 'Exclude pinned',
@@ -94,6 +107,29 @@ function renderSidenav(count = 3): void {
   `
 }
 
+function renderLatestSidenav(): void {
+  document.body.innerHTML = `
+    <bard-sidenav>
+      <side-navigation-content>
+        <div class="sidenav-with-history-container">
+          <div data-test-id="overflow-container"></div>
+          <infinite-scroller>
+            <expandable-section storagekey="chats" data-test-id="chats-expandable-section">
+              <div class="expandable-section-header-row">
+                <button data-test-id="expandable-section-toggle" class="expandable-section-header" aria-expanded="true" aria-controls="sidenav-section-content-chats"><span>Recents</span></button>
+                <div class="expandable-section-header-actions"></div>
+              </div>
+              <div data-test-id="expandable-section-content" class="expandable-section-content">
+                <div class="chat-history"></div>
+              </div>
+            </expandable-section>
+          </infinite-scroller>
+        </div>
+      </side-navigation-content>
+    </bard-sidenav>
+  `
+}
+
 describe('bulk delete DOM helpers', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
@@ -110,7 +146,7 @@ describe('bulk delete DOM helpers', () => {
     toasterCreateMock.mockReset()
   })
 
-  it('injects the entry mount into the chats header without duplicates', () => {
+  it('falls back to the chats header when no actions slot exists', () => {
     renderSidenav()
     const header = findChatHeader()
     expect(header).not.toBeNull()
@@ -120,6 +156,104 @@ describe('bulk delete DOM helpers', () => {
 
     expect(first).toBe(second)
     expect(header!.querySelectorAll('[data-gpk-bulk-delete-entry-spacer]')).toHaveLength(1)
+  })
+
+  it('finds the latest Chats header and places its menu below the header row', () => {
+    renderLatestSidenav()
+    const header = findChatHeader()
+    const headerRow = document.querySelector<HTMLElement>('.expandable-section-header-row')!
+    const headerActions = headerRow.querySelector<HTMLElement>('.expandable-section-header-actions')!
+
+    expect(header).toBe(headerRow.querySelector('button.expandable-section-header'))
+
+    const entryMount = ensureEntryMount(header!)
+    const menu = ensureBulkMenu(header!, {
+      onSelectRecent: vi.fn(),
+      onRecentLimitChange: vi.fn(),
+      onDeselectPinned: vi.fn(),
+      onDeselectAll: vi.fn(),
+      onDelete: vi.fn(),
+    })
+
+    expect(entryMount.isConnected).toBe(true)
+    expect(headerActions.firstElementChild).toBe(entryMount.parentElement)
+    expect(header?.querySelector('[data-gpk-bulk-delete-entry-root]')).toBeNull()
+    expect(headerRow.nextElementSibling).toBe(menu)
+    expect(menu.nextElementSibling?.getAttribute('data-test-id')).toBe('expandable-section-content')
+  })
+
+  it('moves an existing entry mount into the actions slot', () => {
+    renderLatestSidenav()
+    const header = findChatHeader()!
+    const headerActions = document.querySelector<HTMLElement>('.expandable-section-header-actions')!
+    const oldSpacer = document.createElement('div')
+    oldSpacer.setAttribute('data-gpk-bulk-delete-entry-spacer', 'true')
+    const oldMount = document.createElement('div')
+    oldMount.setAttribute('data-gpk-bulk-delete-entry-root', 'true')
+    oldSpacer.appendChild(oldMount)
+    header.appendChild(oldSpacer)
+
+    expect(ensureEntryMount(header)).toBe(oldMount)
+    expect(headerActions.firstElementChild).toBe(oldSpacer)
+    expect(header.querySelector('[data-gpk-bulk-delete-entry-root]')).toBeNull()
+  })
+
+  it('falls back to semantic Chats section and toggle attributes', () => {
+    renderLatestSidenav()
+    const section = document.querySelector<HTMLElement>('expandable-section')!
+    const header = section.querySelector<HTMLButtonElement>('button')!
+    section.removeAttribute('data-test-id')
+    header.removeAttribute('data-test-id')
+    header.removeAttribute('class')
+
+    expect(findChatHeader()).toBe(header)
+  })
+
+  it('limits Chat section matching to the Gemini side navigation', () => {
+    renderLatestSidenav()
+    document.body.insertAdjacentHTML('afterbegin', `
+      <expandable-section storagekey="chats">
+        <button class="expandable-section-header" aria-expanded="true">Decoy Chats</button>
+      </expandable-section>
+    `)
+
+    expect(findChatHeader()?.textContent).toBe('Recents')
+  })
+
+  it('attaches the shared Gemini tooltip to the Bulk Delete entry and cleans it up', async () => {
+    renderLatestSidenav()
+    startBulkDelete()
+    await new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => resolve())
+    })
+    await Promise.resolve()
+
+    const button = document.querySelector<HTMLButtonElement>('.gpk-bulk-delete-entry-button')!
+    await vi.waitFor(() => {
+      expect(vi.mocked(tippy).mock.calls.some(
+        ([reference]) => reference as unknown as Element === button,
+      )).toBe(true)
+    })
+    const tooltipCall = vi.mocked(tippy).mock.calls.find(
+      ([reference]) => reference as unknown as Element === button,
+    )
+    const tooltip = vi.mocked(tippy).mock.results.find(
+      result => (result.value as { reference?: Element }).reference === button,
+    )?.value as { destroy: ReturnType<typeof vi.fn> } | undefined
+    const options = tooltipCall?.[1] as {
+      appendTo?: () => Element
+      content?: string
+      placement?: string
+    } | undefined
+
+    expect(button.hasAttribute('title')).toBe(false)
+    expect(options?.content).toBe('Bulk delete')
+    expect(options?.placement).toBe('right')
+    expect(options?.appendTo?.()).toBe(document.body)
+
+    stopBulkDelete()
+
+    expect(tooltip?.destroy).toHaveBeenCalledOnce()
   })
 
   it('toggles Bulk Delete mode only while the feature controller is running', () => {

--- a/src/entrypoints/content/bulk-delete/index.tsx
+++ b/src/entrypoints/content/bulk-delete/index.tsx
@@ -1,5 +1,6 @@
 import { createRoot, type Root } from 'react-dom/client'
 import { t } from '@/utils/i18n'
+import { destroyGeminiTooltipsWhere } from '../gemini-tooltip'
 import { BulkDeleteEntryHint } from './BulkDeleteEntryHint'
 import { toaster } from '@/components/ui/toaster'
 import {
@@ -129,6 +130,9 @@ function syncCheckboxes(): void {
 
 function reconcile(): void {
   reconcileFrame = null
+  destroyGeminiTooltipsWhere((reference, owner) =>
+    owner === 'bulk-delete' && !reference.isConnected
+  )
   renderEntry()
   if (active) {
     syncCheckboxes()
@@ -375,6 +379,7 @@ export function stopBulkDelete(): void {
   observer?.disconnect()
   observer = null
   document.removeEventListener('keydown', handleKeyDown)
+  destroyGeminiTooltipsWhere((_reference, owner) => owner === 'bulk-delete')
   exitBulkDeleteMode()
   entryRoot?.unmount()
   entryRoot = null

--- a/src/entrypoints/content/gemini-tooltip.ts
+++ b/src/entrypoints/content/gemini-tooltip.ts
@@ -1,7 +1,7 @@
 import tippy, { type Instance } from 'tippy.js'
 
 export type GeminiTooltipPlacement = 'top' | 'right' | 'bottom' | 'left'
-export type GeminiTooltipOwner = 'power-kit-entry' | 'top-bar-action'
+export type GeminiTooltipOwner = 'bulk-delete' | 'power-kit-entry' | 'top-bar-action'
 
 export interface GeminiTooltipOptions {
   content: string


### PR DESCRIPTION
## Summary

- Restore the Bulk Delete entry when Gemini replaces or re-renders its conversation actions.
- Make the entry lookup and DOM reconciliation resilient to the current Gemini menu structure.
- Add regression coverage for the entry lifecycle and DOM updates.

## Root cause

The Bulk Delete integration depended on DOM nodes that Gemini can replace during menu and conversation UI updates. When those nodes were recreated, the injected entry could disappear and was not reliably reattached.

This change reconciles against the current DOM and keeps the injected entry available after the relevant Gemini UI updates.

## Validation

- `git diff --check origin/main...HEAD`
- Added regression tests in `src/entrypoints/content/bulk-delete/index.test.tsx`