### PR TITLE
fix(shortcuts): make New Chat navigation resilient

### DIFF
--- a/src/components/setting-panel/views/chain-prompt/RunModal.tsx
+++ b/src/components/setting-panel/views/chain-prompt/RunModal.tsx
@@ -26,7 +26,7 @@ import { executionCoordinator } from '@/services/executionCoordinator'
 import { useChainPromptStore, startRun, updateStepStatus, completeRun } from '@/stores/chainPromptStore'
 import { toaster } from '@/components/ui/toaster'
 import { t } from '@/utils/i18n'
-import { createNewChatByClick } from '@/utils/chatActions'
+import { createNewChatForChainPrompt } from '@/utils/chatActions'
 import { hasChatHistory, getChatSummary, getDefaultChatWindow } from '@/utils/messageUtils'
 import { ConfirmNewChatDialog } from './ConfirmNewChatDialog'
 import { useEventEmitter } from '@/hooks/useEventBus'
@@ -110,7 +110,7 @@ export function RunModal({ prompt, open, onClose, onEdit }: RunModalProps) {
     setShowConfirmDialog(false)
 
     // Create new chat
-    const success = await createNewChatByClick()
+    const success = await createNewChatForChainPrompt()
 
     if (!success) {
       toaster.create({
@@ -388,5 +388,4 @@ export function RunModal({ prompt, open, onClose, onEdit }: RunModalProps) {
     </Dialog.Root>
   )
 }
-
 

--- a/src/utils/chatActions.test.ts
+++ b/src/utils/chatActions.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  createNewChatByClick,
+  createNewChatForChainPrompt,
   openGems,
   openLibrary,
+  openNewChat,
   openTemporaryChatByClick,
   toggleSidebar,
 } from './chatActions'
@@ -11,32 +12,181 @@ import {
 describe('chatActions new chat', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
+    window.history.replaceState({}, '', '/')
   })
 
-  it('clicks the visible compact entry when the SideNav is collapsed', async () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('clicks the current SideNav New chat entry', async () => {
     document.body.innerHTML = `
       <side-nav-sparkle-button>
         <a aria-label="New chat" data-test-id="side-nav-sparkle-button" href="/" style="display: none"></a>
       </side-nav-sparkle-button>
-      <bard-sidenav class="collapsed">
-        <gem-icon-button>
+      <bard-sidenav>
+        <gem-nav-list-item data-test-id="new-chat-button">
           <a aria-label="New chat" href="/app"></a>
-        </gem-icon-button>
+        </gem-nav-list-item>
       </bard-sidenav>
       <chat-window></chat-window>
       <rich-textarea></rich-textarea>
     `
     const hiddenLink = document.querySelector<HTMLAnchorElement>('[data-test-id="side-nav-sparkle-button"]')!
-    const compactLink = document.querySelector<HTMLAnchorElement>('gem-icon-button > a[href="/app"]')!
+    const newChatLink = document.querySelector<HTMLAnchorElement>(
+      'gem-nav-list-item[data-test-id="new-chat-button"] > a[href="/app"]',
+    )!
     const hiddenClickSpy = vi.fn()
-    const compactClickSpy = vi.fn()
+    const newChatClickSpy = vi.fn()
     hiddenLink.addEventListener('click', hiddenClickSpy)
-    compactLink.addEventListener('click', compactClickSpy)
+    newChatLink.addEventListener('click', newChatClickSpy)
 
-    await expect(createNewChatByClick()).resolves.toBe(true)
+    await expect(createNewChatForChainPrompt()).resolves.toBe(true)
 
     expect(hiddenClickSpy).not.toHaveBeenCalled()
-    expect(compactClickSpy).toHaveBeenCalledTimes(1)
+    expect(newChatClickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('recognizes the SideNav aria-label contract without an /app href', async () => {
+    document.body.innerHTML = `
+      <bard-sidenav>
+        <a aria-label="New chat" href="/different-route"></a>
+      </bard-sidenav>
+      <chat-window></chat-window>
+      <rich-textarea></rich-textarea>
+    `
+    const newChatLink = document.querySelector<HTMLAnchorElement>('bard-sidenav a')!
+    const clickSpy = vi.fn((event: MouseEvent) => event.preventDefault())
+    newChatLink.addEventListener('click', clickSpy)
+
+    await expect(createNewChatForChainPrompt()).resolves.toBe(true)
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('recognizes the SideNav data-test-id contract without New chat link attributes', async () => {
+    document.body.innerHTML = `
+      <bard-sidenav>
+        <gem-nav-list-item data-test-id="new-chat-button">
+          <a href="/different-route"></a>
+        </gem-nav-list-item>
+      </bard-sidenav>
+      <chat-window></chat-window>
+      <rich-textarea></rich-textarea>
+    `
+    const newChatLink = document.querySelector<HTMLAnchorElement>(
+      'gem-nav-list-item[data-test-id="new-chat-button"] > a',
+    )!
+    const clickSpy = vi.fn((event: MouseEvent) => event.preventDefault())
+    newChatLink.addEventListener('click', clickSpy)
+
+    await expect(createNewChatForChainPrompt()).resolves.toBe(true)
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('recognizes the unscoped aria-label fallback when SideNav is unavailable', async () => {
+    document.body.innerHTML = `
+      <a aria-label="New chat" href="/different-route"></a>
+      <chat-window></chat-window>
+      <rich-textarea></rich-textarea>
+    `
+    const newChatLink = document.querySelector<HTMLAnchorElement>('a[aria-label="New chat"]')!
+    const clickSpy = vi.fn((event: MouseEvent) => event.preventDefault())
+    newChatLink.addEventListener('click', clickSpy)
+
+    await expect(createNewChatForChainPrompt()).resolves.toBe(true)
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('recognizes the unscoped data-test-id fallback when SideNav is unavailable', async () => {
+    document.body.innerHTML = `
+      <gem-nav-list-item data-test-id="new-chat-button">
+        <a href="/different-route"></a>
+      </gem-nav-list-item>
+      <chat-window></chat-window>
+      <rich-textarea></rich-textarea>
+    `
+    const newChatLink = document.querySelector<HTMLAnchorElement>(
+      'gem-nav-list-item[data-test-id="new-chat-button"] > a',
+    )!
+    const clickSpy = vi.fn((event: MouseEvent) => event.preventDefault())
+    newChatLink.addEventListener('click', clickSpy)
+
+    await expect(createNewChatForChainPrompt()).resolves.toBe(true)
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the native control when it moves an existing chat to /app', async () => {
+    window.history.replaceState({}, '', '/app/current-chat')
+    document.body.innerHTML = `
+      <bard-sidenav>
+        <gem-nav-list-item data-test-id="new-chat-button">
+          <a aria-label="New chat" href="/app"></a>
+        </gem-nav-list-item>
+      </bard-sidenav>
+    `
+
+    const newChatButton = document.querySelector<HTMLAnchorElement>(
+      '[data-test-id="new-chat-button"] > a[href="/app"]',
+    )!
+    const clickSpy = vi.fn(() => {
+      window.history.pushState({}, '', '/app')
+    })
+    newChatButton.addEventListener('click', clickSpy)
+
+    await expect(openNewChat()).resolves.toBeUndefined()
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(window.location.pathname).toBe('/app')
+  })
+
+  it('does nothing when already on the blank chat route', async () => {
+    window.history.replaceState({}, '', '/app')
+    document.body.innerHTML = '<a aria-label="New chat" href="/app"></a>'
+
+    const newChatButton = document.querySelector<HTMLAnchorElement>('a[aria-label="New chat"]')!
+    const clickSpy = vi.fn()
+    newChatButton.addEventListener('click', clickSpy)
+
+    await expect(openNewChat()).resolves.toBeUndefined()
+
+    expect(clickSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a real route navigation when no native control is available', async () => {
+    window.history.replaceState({}, '', '/app/current-chat')
+    const assignSpy = vi.spyOn(window.location, 'assign').mockImplementation(() => undefined)
+
+    await expect(openNewChat()).resolves.toBeUndefined()
+
+    expect(assignSpy).toHaveBeenCalledWith('/app')
+  })
+
+  it('falls back to a real route navigation when the native control does not change routes', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/app/current-chat')
+    document.body.innerHTML = `
+      <bard-sidenav>
+        <gem-nav-list-item data-test-id="new-chat-button">
+          <a aria-label="New chat" href="/app"></a>
+        </gem-nav-list-item>
+      </bard-sidenav>
+    `
+    const newChatButton = document.querySelector<HTMLAnchorElement>(
+      '[data-test-id="new-chat-button"] > a[href="/app"]',
+    )!
+    newChatButton.addEventListener('click', (event) => event.preventDefault())
+    const assignSpy = vi.spyOn(window.location, 'assign').mockImplementation(() => undefined)
+
+    const navigation = openNewChat()
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(navigation).resolves.toBeUndefined()
+
+    expect(assignSpy).toHaveBeenCalledWith('/app')
   })
 })
 
@@ -53,6 +203,25 @@ describe('chatActions temporary chat', () => {
       </temp-chat-button>
     `
     window.history.replaceState({}, '', '/app')
+
+    const temporaryChatButton = document.querySelector<HTMLElement>(
+      'temp-chat-button > gem-icon-button',
+    )!
+    const clickSpy = vi.fn()
+    temporaryChatButton.addEventListener('click', clickSpy)
+
+    await expect(openTemporaryChatByClick()).resolves.toBe(true)
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicks the temporary chat control directly from an existing conversation', async () => {
+    document.body.innerHTML = `
+      <temp-chat-button>
+        <gem-icon-button></gem-icon-button>
+      </temp-chat-button>
+    `
+    window.history.replaceState({}, '', '/app/current-chat')
 
     const temporaryChatButton = document.querySelector<HTMLElement>(
       'temp-chat-button > gem-icon-button',

--- a/src/utils/chatActions.test.ts
+++ b/src/utils/chatActions.test.ts
@@ -260,6 +260,67 @@ describe('chatActions temporary chat', () => {
 
     expect(clickSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('opens New chat, waits for the Temporary chat control, then clicks it', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/app/current-chat')
+    document.body.innerHTML = `
+      <bard-sidenav>
+        <gem-nav-list-item data-test-id="new-chat-button">
+          <a aria-label="New chat" href="/app"></a>
+        </gem-nav-list-item>
+      </bard-sidenav>
+    `
+    const newChatButton = document.querySelector<HTMLAnchorElement>(
+      'gem-nav-list-item[data-test-id="new-chat-button"] > a',
+    )!
+    const temporaryChatClickSpy = vi.fn()
+    const newChatClickSpy = vi.fn(() => {
+      window.history.pushState({}, '', '/app')
+      window.setTimeout(() => {
+        document.body.insertAdjacentHTML('beforeend', `
+          <temp-chat-button>
+            <gem-icon-button></gem-icon-button>
+          </temp-chat-button>
+        `)
+        document.querySelector<HTMLElement>('temp-chat-button > gem-icon-button')!
+          .addEventListener('click', temporaryChatClickSpy)
+      }, 100)
+    })
+    newChatButton.addEventListener('click', newChatClickSpy)
+
+    const opening = openTemporaryChatByClick()
+    await vi.advanceTimersByTimeAsync(150)
+
+    await expect(opening).resolves.toBe(true)
+    expect(newChatClickSpy).toHaveBeenCalledTimes(1)
+    expect(temporaryChatClickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the SPA route fallback before waiting for the Temporary chat control', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/app/current-chat')
+    const popStateSpy = vi.fn()
+    const temporaryChatClickSpy = vi.fn()
+    window.addEventListener('popstate', popStateSpy, { once: true })
+    window.setTimeout(() => {
+      document.body.insertAdjacentHTML('beforeend', `
+        <temp-chat-button>
+          <gem-icon-button></gem-icon-button>
+        </temp-chat-button>
+      `)
+      document.querySelector<HTMLElement>('temp-chat-button > gem-icon-button')!
+        .addEventListener('click', temporaryChatClickSpy)
+    }, 100)
+
+    const opening = openTemporaryChatByClick()
+    await vi.advanceTimersByTimeAsync(150)
+
+    await expect(opening).resolves.toBe(true)
+    expect(window.location.pathname).toBe('/app')
+    expect(popStateSpy).toHaveBeenCalledTimes(1)
+    expect(temporaryChatClickSpy).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('chatActions sidebar toggle', () => {

--- a/src/utils/chatActions.test.ts
+++ b/src/utils/chatActions.test.ts
@@ -48,6 +48,29 @@ describe('chatActions new chat', () => {
     expect(newChatClickSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('clicks New chat when a confirmation dialog marks Gemini app root aria-hidden', async () => {
+    document.body.innerHTML = `
+      <chat-app-orchestrator id="app-root" aria-hidden="true">
+        <bard-sidenav>
+          <gem-nav-list-item data-test-id="new-chat-button">
+            <a aria-label="New chat" href="/app"></a>
+          </gem-nav-list-item>
+        </bard-sidenav>
+        <chat-window></chat-window>
+        <rich-textarea></rich-textarea>
+      </chat-app-orchestrator>
+    `
+    const newChatLink = document.querySelector<HTMLAnchorElement>(
+      'gem-nav-list-item[data-test-id="new-chat-button"] > a',
+    )!
+    const clickSpy = vi.fn()
+    newChatLink.addEventListener('click', clickSpy)
+
+    await expect(createNewChatForChainPrompt()).resolves.toBe(true)
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('recognizes the SideNav aria-label contract without an /app href', async () => {
     document.body.innerHTML = `
       <bard-sidenav>

--- a/src/utils/chatActions.test.ts
+++ b/src/utils/chatActions.test.ts
@@ -180,16 +180,18 @@ describe('chatActions new chat', () => {
     expect(clickSpy).not.toHaveBeenCalled()
   })
 
-  it('falls back to a real route navigation when no native control is available', async () => {
+  it('falls back to a SPA route transition when no native control is available', async () => {
     window.history.replaceState({}, '', '/app/current-chat')
-    const assignSpy = vi.spyOn(window.location, 'assign').mockImplementation(() => undefined)
+    const popStateSpy = vi.fn()
+    window.addEventListener('popstate', popStateSpy, { once: true })
 
     await expect(openNewChat()).resolves.toBeUndefined()
 
-    expect(assignSpy).toHaveBeenCalledWith('/app')
+    expect(window.location.pathname).toBe('/app')
+    expect(popStateSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to a real route navigation when the native control does not change routes', async () => {
+  it('falls back to a SPA route transition when the native control does not change routes', async () => {
     vi.useFakeTimers()
     window.history.replaceState({}, '', '/app/current-chat')
     document.body.innerHTML = `
@@ -203,13 +205,15 @@ describe('chatActions new chat', () => {
       '[data-test-id="new-chat-button"] > a[href="/app"]',
     )!
     newChatButton.addEventListener('click', (event) => event.preventDefault())
-    const assignSpy = vi.spyOn(window.location, 'assign').mockImplementation(() => undefined)
+    const popStateSpy = vi.fn()
+    window.addEventListener('popstate', popStateSpy, { once: true })
 
     const navigation = openNewChat()
     await vi.advanceTimersByTimeAsync(1000)
     await expect(navigation).resolves.toBeUndefined()
 
-    expect(assignSpy).toHaveBeenCalledWith('/app')
+    expect(window.location.pathname).toBe('/app')
+    expect(popStateSpy).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/utils/chatActions.ts
+++ b/src/utils/chatActions.ts
@@ -7,6 +7,8 @@ import { hasChatHistory, getChatSummary, getDefaultChatWindow } from './messageU
 const NEW_CHAT_PATH = '/app'
 const NEW_CHAT_ROUTE_TIMEOUT_MS = 1000
 const NEW_CHAT_ROUTE_POLL_INTERVAL_MS = 50
+const TEMPORARY_CHAT_BUTTON_TIMEOUT_MS = 1000
+const TEMPORARY_CHAT_BUTTON_POLL_INTERVAL_MS = 50
 
 const NEW_CHAT_SELECTORS = [
   // Any one of these independent contracts identifies New chat in SideNav.
@@ -171,12 +173,47 @@ export const openNewChat = async (): Promise<void> => {
   navigateToNewChatViaSpa()
 }
 
-function clickTemporaryChatButton(): boolean {
-  const temporaryChatButton = findVisibleElement([
-    'temp-chat-button > gem-icon-button',
-    'temp-chat-button gem-icon-button',
-    'temp-chat-button button',
-  ])
+const TEMPORARY_CHAT_BUTTON_SELECTORS = [
+  'temp-chat-button > gem-icon-button',
+  'temp-chat-button gem-icon-button',
+  'temp-chat-button button',
+] as const
+
+function findTemporaryChatButton(): HTMLElement | null {
+  return findVisibleElement(TEMPORARY_CHAT_BUTTON_SELECTORS)
+}
+
+function waitForTemporaryChatButton(): Promise<HTMLElement | null> {
+  const existingButton = findTemporaryChatButton()
+  if (existingButton) {
+    return Promise.resolve(existingButton)
+  }
+
+  return new Promise((resolve) => {
+    let intervalId = 0
+    let timeoutId = 0
+
+    const finish = (button: HTMLElement | null) => {
+      window.clearInterval(intervalId)
+      window.clearTimeout(timeoutId)
+      resolve(button)
+    }
+
+    intervalId = window.setInterval(() => {
+      const button = findTemporaryChatButton()
+      if (button) {
+        finish(button)
+      }
+    }, TEMPORARY_CHAT_BUTTON_POLL_INTERVAL_MS)
+
+    timeoutId = window.setTimeout(() => {
+      finish(findTemporaryChatButton())
+    }, TEMPORARY_CHAT_BUTTON_TIMEOUT_MS)
+  })
+}
+
+function clickTemporaryChatButton(button = findTemporaryChatButton()): boolean {
+  const temporaryChatButton = button
 
   if (!temporaryChatButton) {
     console.error('[Shortcut] Temporary chat button not found')
@@ -191,9 +228,31 @@ function clickTemporaryChatButton(): boolean {
  * Open a new temporary chat from Gemini's page controls.
  */
 export const openTemporaryChatByClick = async (): Promise<boolean> => {
-  // Gemini's native control handles the transition from either an existing chat
-  // or the blank chat page. Avoid an unnecessary New Chat transition first.
-  return clickTemporaryChatButton()
+  const existingButton = findTemporaryChatButton()
+  if (existingButton) {
+    return clickTemporaryChatButton(existingButton)
+  }
+
+  if (!isNewChatRoute()) {
+    const newChatButton = findNewChatButton()
+
+    if (newChatButton) {
+      try {
+        newChatButton.click()
+        if (!await waitForNewChatRoute()) {
+          navigateToNewChatViaSpa()
+        }
+      } catch (error) {
+        console.warn('[Shortcut] Failed to click New chat before opening Temporary chat:', error)
+        navigateToNewChatViaSpa()
+      }
+    } else {
+      navigateToNewChatViaSpa()
+    }
+  }
+
+  const temporaryChatButton = await waitForTemporaryChatButton()
+  return clickTemporaryChatButton(temporaryChatButton)
 }
 
 function openSideNavEntry(selectors: readonly string[], label: string): boolean {

--- a/src/utils/chatActions.ts
+++ b/src/utils/chatActions.ts
@@ -53,8 +53,22 @@ function findVisibleElement(selectors: readonly string[]): HTMLElement | null {
   return null
 }
 
+function findFirstElement(selectors: readonly string[]): HTMLElement | null {
+  for (const selector of selectors) {
+    const element = document.querySelector<HTMLElement>(selector)
+    if (element) {
+      return element
+    }
+  }
+
+  return null
+}
+
 function findNewChatButton(): HTMLElement | null {
-  return findVisibleElement(NEW_CHAT_SELECTORS)
+  // Chain Prompt may invoke this while its confirmation dialog marks Gemini's
+  // app root aria-hidden. New Chat is an explicit native target, so do not
+  // reject it based on visibility state inherited from that dialog.
+  return findFirstElement(NEW_CHAT_SELECTORS)
 }
 
 function isNewChatRoute(): boolean {

--- a/src/utils/chatActions.ts
+++ b/src/utils/chatActions.ts
@@ -102,8 +102,9 @@ function waitForNewChatRoute(): Promise<boolean> {
   })
 }
 
-function navigateToNewChat(): void {
-  window.location.assign(NEW_CHAT_PATH)
+function navigateToNewChatViaSpa(): void {
+  window.history.pushState({}, '', NEW_CHAT_PATH)
+  window.dispatchEvent(new PopStateEvent('popstate', { state: window.history.state }))
 }
 
 /**
@@ -144,7 +145,7 @@ export const createNewChatForChainPrompt = async (): Promise<boolean> => {
 
 /**
  * Open a new Gemini chat through the native control when possible.
- * Falls back to a real page navigation when the control is unavailable or does
+ * Falls back to a SPA route transition when the control is unavailable or does
  * not update the route promptly.
  */
 export const openNewChat = async (): Promise<void> => {
@@ -154,7 +155,7 @@ export const openNewChat = async (): Promise<void> => {
 
   const button = findNewChatButton()
   if (!button) {
-    navigateToNewChat()
+    navigateToNewChatViaSpa()
     return
   }
 
@@ -167,7 +168,7 @@ export const openNewChat = async (): Promise<void> => {
     console.warn('[Chat Action] Failed to click New chat:', error)
   }
 
-  navigateToNewChat()
+  navigateToNewChatViaSpa()
 }
 
 function clickTemporaryChatButton(): boolean {

--- a/src/utils/chatActions.ts
+++ b/src/utils/chatActions.ts
@@ -1,16 +1,26 @@
 /**
- * Chat action utilities for chain prompt execution
- * Handles chat history detection and new chat creation
+ * Chat action utilities for Gemini page navigation and Chain Prompt execution.
  */
 
-import { GEM_EXT_EVENTS } from '@/common/event'
 import { hasChatHistory, getChatSummary, getDefaultChatWindow } from './messageUtils'
 
 const NEW_CHAT_PATH = '/app'
+const NEW_CHAT_ROUTE_TIMEOUT_MS = 1000
+const NEW_CHAT_ROUTE_POLL_INTERVAL_MS = 50
 
-const delay = (ms: number): Promise<void> => new Promise((resolve) => {
-  window.setTimeout(resolve, ms)
-})
+const NEW_CHAT_SELECTORS = [
+  // Any one of these independent contracts identifies New chat in SideNav.
+  'bard-sidenav a[href="/app"]',
+  'bard-sidenav a[aria-label="New chat"]',
+  'bard-sidenav gem-nav-list-item[data-test-id="new-chat-button"] > a',
+
+  // Fallback for the compact top-level entry.
+  'side-nav-sparkle-button > a[aria-label="New chat"]',
+
+  // Gemini can move the same controls outside of the SideNav container.
+  'a[aria-label="New chat"]',
+  'gem-nav-list-item[data-test-id="new-chat-button"] > a',
+] as const
 
 function isElementVisible(element: HTMLElement): boolean {
   let currentElement: HTMLElement | null = element
@@ -43,35 +53,58 @@ function findVisibleElement(selectors: readonly string[]): HTMLElement | null {
   return null
 }
 
+function findNewChatButton(): HTMLElement | null {
+  return findVisibleElement(NEW_CHAT_SELECTORS)
+}
+
+function isNewChatRoute(): boolean {
+  return window.location.pathname === NEW_CHAT_PATH
+}
+
+function waitForNewChatRoute(): Promise<boolean> {
+  if (isNewChatRoute()) {
+    return Promise.resolve(true)
+  }
+
+  return new Promise((resolve) => {
+    let intervalId = 0
+    let timeoutId = 0
+
+    const finish = (navigated: boolean) => {
+      window.clearInterval(intervalId)
+      window.clearTimeout(timeoutId)
+      resolve(navigated)
+    }
+
+    intervalId = window.setInterval(() => {
+      if (isNewChatRoute()) {
+        finish(true)
+      }
+    }, NEW_CHAT_ROUTE_POLL_INTERVAL_MS)
+
+    timeoutId = window.setTimeout(() => {
+      finish(isNewChatRoute())
+    }, NEW_CHAT_ROUTE_TIMEOUT_MS)
+  })
+}
+
+function navigateToNewChat(): void {
+  window.location.assign(NEW_CHAT_PATH)
+}
+
 /**
- * Create a new chat by simulating click on the "New chat" button
- * Preserves Content Script state (unlike navigation-based approach)
+ * Create a new chat for Chain Prompt, then wait until its editor is ready.
+ * This intentionally avoids hard navigation because the Chain Prompt run must
+ * continue in the existing content-script context.
  * @returns Promise<boolean> - true if successful, false otherwise
  */
-export const createNewChatByClick = async (): Promise<boolean> => {
+export const createNewChatForChainPrompt = async (): Promise<boolean> => {
   try {
     // Get chat summary before creating new chat
     const beforeSummary = getChatSummary()
     const beforeCount = beforeSummary.messageCount
     
-    // Button selectors (ordered by priority)
-    const selectors = [
-      // Collapsed SideNav uses a compact gem-icon-button entry.
-      'bard-sidenav.collapsed gem-icon-button > a[aria-label="New chat"][href="/app"]',
-
-      // Primary selector (based on Gemini DOM structure)
-      'side-navigation-v2 side-nav-action-button[data-test-id="new-chat-button"] a[aria-label="New chat"]',
-      
-      // Alternative selectors
-      'a[aria-label="New chat"]',
-      'side-nav-action-button[data-test-id="new-chat-button"] a',
-      '[data-test-id="new-chat-button"]',
-      
-      // Generic fallbacks
-      'button[aria-label*="New"]',
-    ]
-    
-    const button = findVisibleElement(selectors)
+    const button = findNewChatButton()
     
     if (!button) {
       console.error('[Chain Prompt] New chat button not found')
@@ -96,47 +129,31 @@ export const createNewChatByClick = async (): Promise<boolean> => {
 }
 
 /**
- * Open a new chat by moving Gemini to the blank /app route.
- * Use this as a fallback when Gemini's native button is unavailable.
+ * Open a new Gemini chat through the native control when possible.
+ * Falls back to a real page navigation when the control is unavailable or does
+ * not update the route promptly.
  */
-export const openNewChatByRoute = async (): Promise<boolean> => {
+export const openNewChat = async (): Promise<void> => {
+  if (isNewChatRoute()) {
+    return
+  }
+
+  const button = findNewChatButton()
+  if (!button) {
+    navigateToNewChat()
+    return
+  }
+
   try {
-    const beforeSummary = getChatSummary()
-    const beforeCount = beforeSummary.messageCount
-
-    if (window.location.pathname !== NEW_CHAT_PATH) {
-      window.history.pushState({}, '', NEW_CHAT_PATH)
-      window.dispatchEvent(new PopStateEvent('popstate', { state: window.history.state }))
-      window.dispatchEvent(new CustomEvent(GEM_EXT_EVENTS.URL_CHANGE, {
-        detail: {
-          url: window.location.href,
-          timestamp: Date.now(),
-        },
-      }))
+    button.click()
+    if (await waitForNewChatRoute()) {
+      return
     }
-
-    const success = await waitForNewChatReady(beforeCount)
-    if (success) {
-      return true
-    }
-
-    return false
   } catch (error) {
-    console.error('[Shortcut] Failed to open new chat by route:', error)
-    return false
-  }
-}
-
-/**
- * Open a new chat with Gemini's native UI first, then fall back to route change.
- */
-export const openNewChat = async (): Promise<boolean> => {
-  const clicked = await createNewChatByClick()
-  if (clicked) {
-    return true
+    console.warn('[Chat Action] Failed to click New chat:', error)
   }
 
-  return openNewChatByRoute()
+  navigateToNewChat()
 }
 
 function clickTemporaryChatButton(): boolean {
@@ -159,18 +176,8 @@ function clickTemporaryChatButton(): boolean {
  * Open a new temporary chat from Gemini's page controls.
  */
 export const openTemporaryChatByClick = async (): Promise<boolean> => {
-  // The temporary chat control is already available on Gemini's blank chat page.
-  // Avoid waiting for a redundant new-chat transition in this common shortcut path.
-  if (window.location.pathname === NEW_CHAT_PATH) {
-    return clickTemporaryChatButton()
-  }
-
-  const newChatReady = await openNewChat()
-  if (!newChatReady) {
-    return false
-  }
-
-  await delay(500)
+  // Gemini's native control handles the transition from either an existing chat
+  // or the blank chat page. Avoid an unnecessary New Chat transition first.
   return clickTemporaryChatButton()
 }
 

--- a/src/utils/chatActions.ts
+++ b/src/utils/chatActions.ts
@@ -181,7 +181,7 @@ export const openNewChat = async (): Promise<void> => {
 }
 
 function findTemporaryChatButton(): HTMLElement | null {
-  return findVisibleElement(TEMPORARY_CHAT_BUTTON_SELECTORS)
+  return findFirstElement(TEMPORARY_CHAT_BUTTON_SELECTORS)
 }
 
 function waitForTemporaryChatButton(): Promise<HTMLElement | null> {

--- a/src/utils/chatActions.ts
+++ b/src/utils/chatActions.ts
@@ -10,6 +10,13 @@ const NEW_CHAT_ROUTE_POLL_INTERVAL_MS = 50
 const TEMPORARY_CHAT_BUTTON_TIMEOUT_MS = 1000
 const TEMPORARY_CHAT_BUTTON_POLL_INTERVAL_MS = 50
 
+// Gemini's native entry for switching the active page into Temporary Chat.
+const TEMPORARY_CHAT_BUTTON_SELECTORS = [
+  'temp-chat-button > gem-icon-button',
+  'temp-chat-button gem-icon-button',
+  'temp-chat-button button',
+] as const
+
 const NEW_CHAT_SELECTORS = [
   // Any one of these independent contracts identifies New chat in SideNav.
   'bard-sidenav a[href="/app"]',
@@ -172,12 +179,6 @@ export const openNewChat = async (): Promise<void> => {
 
   navigateToNewChatViaSpa()
 }
-
-const TEMPORARY_CHAT_BUTTON_SELECTORS = [
-  'temp-chat-button > gem-icon-button',
-  'temp-chat-button gem-icon-button',
-  'temp-chat-button button',
-] as const
 
 function findTemporaryChatButton(): HTMLElement | null {
   return findVisibleElement(TEMPORARY_CHAT_BUTTON_SELECTORS)


### PR DESCRIPTION
## Summary

- Prefer Gemini's native New Chat control, then confirm that the route reaches `/app` within one second.
- Fall back to an in-page SPA transition (`pushState` plus `popstate`) if the native entry is missing or does not update the route.
- Keep shortcut navigation separate from Chain Prompt's editor-readiness polling.
- Let Chain Prompt target the explicit New Chat entry while its confirmation dialog temporarily marks Gemini's app root as `aria-hidden`.

## Root cause

The New Chat shortcut previously reused Chain Prompt's three-second editor-readiness wait. A shortcut only needs navigation, so an otherwise successful native click could be reported as a Chain Prompt timeout. The Chain Prompt confirmation dialog could also filter out the intended native entry through inherited `aria-hidden`.

## Validation

- `pnpm test:run src/utils/chatActions.test.ts src/services/shortcuts/definitions.test.ts`
- `pnpm compile`

Related to #43